### PR TITLE
Do Sumw2 in line line instead of in >500 lines

### DIFF
--- a/Analyzer/interface/TupleMaker.h
+++ b/Analyzer/interface/TupleMaker.h
@@ -254,7 +254,6 @@ void TupleMaker::initializeTuple(Tuple *&tuple,
                                  float GlobalMinTOF) {
   std::string Name;
   
-  // TODO: when this is used we dont need the ->Sumw2(); call every time, let's test this
   TH1::SetDefaultSumw2(kTRUE);
 
   tuple->IntLumi = dir.make<TProfile>("IntLumi", ";IntLumi", 1, 0, 1);
@@ -272,25 +271,18 @@ void TupleMaker::initializeTuple(Tuple *&tuple,
   tuple->CutFlowPfType = dir.make<TH2F>("CutFlowPfType", ";PfType;CutFlowIndex", 9, 0., 9., 17, 0., 17.);
 
   tuple->N1_Eta = dir.make<TH1F>("N1_Eta",";#eta", 50, -2.6, 2.6);
-  tuple->N1_Eta->Sumw2();
   tuple->N1_Pt = dir.make<TH1F>("N1_Pt", ";p_{T} (GeV)", 50, 0, PtHistoUpperBound);
-  tuple->N1_Pt->Sumw2();
   tuple->N1_Pt_lowPt = dir.make<TH1F>("N1_Pt_lowPt", ";p_{T} (GeV)", 50, 0, 500);
-  tuple->N1_Pt_lowPt->Sumw2();
   tuple->N1_Chi2oNdof = dir.make<TH1F>("N1_Chi2oNdof", ";#chi^2 / N_{dof}", 20, 0, 20);
   tuple->N1_Qual = dir.make<TH1F>("N1_Qual",";Quality", 20, -0.5, 19.5);
-  tuple->N1_Qual->Sumw2();
   tuple->N1_TNOM = dir.make<TH1F>("N1_TNOM", "N1_TNOM;Number of measurments", 40, -0.5, 39.5);
-  tuple->N1_TNOM->Sumw2();
   tuple->N1_TNOPH = dir.make<TH1F>("N1_TNOPH",";Number of pixel hits", 8, -0.5, 7.5);
-  tuple->N1_TNOPH->Sumw2();
   tuple->N1_TNOHFraction = dir.make<TH1F>("N1_TNOHFraction",";Number of valid hit fraction", 50, 0, 1);
 //  tuple->N1_nDof = dir.make<TH1F>("nDof",";N_{dof}", 40, -0.5, 39.5);
 //  tuple->N1_tofError = dir.make<TH1F>("tofError", ";tofError", 25, 0, 0.25);
   tuple->N1_TIsol = dir.make<TH1F>("TIsol", "TIsol", 25, 0, 100);
   tuple->N1_EoP = dir.make<TH1F>("N1_EoP",";Energy / Momentum", 25, 0, 1.5);
   tuple->N1_dRMinPfJet= dir.make<TH1F>("N1_dRMinPfJet",";dRMinPfJet",100,0.,1.5);
-  tuple->N1_dRMinPfJet->Sumw2();
   tuple->N1_SumpTOverpT = dir.make<TH1F>("N1_SumpTOverpT",";SumpTOverpT", 80, 0, 2);
   tuple->N1_Ih = dir.make<TH1F>("N1_Ih",";I_{h}", 200, 0, dEdxM_UpLim);
   tuple->N1_MTOF = dir.make<TH1F>("N1_MTOF", ";TOF", 50, -2, 5);
@@ -300,377 +292,218 @@ void TupleMaker::initializeTuple(Tuple *&tuple,
   tuple->NVTrack = dir.make<TH1F>("NVTrack", ";NVTrack", 1, 0, 1);
   tuple->N1_Stations = dir.make<TH1F>("N1_Stations", ";Stations", 1, 0, 1);
   tuple->N1_Dxy = dir.make<TH1F>("N1_Dxy",";d_{xy} (cm)", 200, -0.1, 0.1);
-  tuple->N1_Dxy->Sumw2();
   tuple->N1_Dz = dir.make<TH1F>("N1_Dz",";d_{z} (cm)", 200, -0.3, 0.3);
-  tuple->N1_Dz->Sumw2();
 
   tuple->N1_PtErrOverPt = dir.make<TH1F>("N1_PtErrOverPt", ";PtErrOverPt", 40, 0, 1);
-  tuple->N1_PtErrOverPt->Sumw2();
 
   tuple->N1_SegSep = dir.make<TH1F>("N1_SegSep", ";SegSep", 1, 0, 1);
 
   tuple->FailDz = dir.make<TH1F>("FailDz", ";FailDz", 1, 0, 1);
 
   tuple->N1_ProbQ = dir.make<TH1F>("N1_ProbQ", ";ProbQ", 100, 0, 1);
-  tuple->N1_ProbQ->Sumw2();
   tuple->N1_ProbQVsIas = dir.make<TH2F>("N1_ProbQVsIas",";ProbQ;I_{as}", 100, 0.0, 1.0, 100, 0.0, 1.0);
-  tuple->N1_ProbQVsIas->Sumw2();
   tuple->N1_ProbXY = dir.make<TH1F>("N1_ProbXY",";ProbXY", 100, 0, 1);
-  tuple->N1_ProbXY->Sumw2();
   tuple->N1_MiniRelIsoAll = dir.make<TH1F>("N1_MiniRelIsoAll", ";MiniRelIsoAll",  150, 0.0, 1.5);
-  tuple->N1_MiniRelIsoAll->Sumw2();
   tuple->N1_MiniRelIsoAll_lowMiniRelIso = dir.make<TH1F>("N1_MiniRelIsoAll_lowMiniRelIso", ";MiniRelIsoAll",  100, 0.0, 0.1);
-  tuple->N1_MiniRelIsoAll_lowMiniRelIso->Sumw2();
 
   tuple->N1_pfType = dir.make<TH1F>("N1_pfType", ";pfType", 9, 0, 9);
-  tuple->N1_pfType->Sumw2();
 
 
   tuple->HSCPE = dir.make<TH1F>("HSCPE", ";NCuts;HSCPE", NCuts, 0, NCuts);
-  tuple->HSCPE->Sumw2();
 
   tuple->HSCPE_SystP = dir.make<TH1F>("HSCPE_SystP", ";NCuts;HSCPE_SystP", NCuts, 0, NCuts);
-  tuple->HSCPE_SystP->Sumw2();
 
   tuple->HSCPE_SystI = dir.make<TH1F>("HSCPE_SystI", ";NCuts;HSCPE_SystI", NCuts, 0, NCuts);
-  tuple->HSCPE_SystI->Sumw2();
 
   tuple->HSCPE_SystM = dir.make<TH1F>("HSCPE_SystM", ";NCuts;HSCPE_SystM", NCuts, 0, NCuts);
-  tuple->HSCPE_SystM->Sumw2();
 
   tuple->HSCPE_SystT = dir.make<TH1F>("HSCPE_SystT", ";NCuts;HSCPE_SystT", NCuts, 0, NCuts);
-  tuple->HSCPE_SystT->Sumw2();
 
   tuple->HSCPE_SystPU = dir.make<TH1F>("HSCPE_SystPU", ";NCuts;HSCPE_SystPU", NCuts, 0, NCuts);
-  tuple->HSCPE_SystPU->Sumw2();
 
   tuple->HSCPE_SystHUp = dir.make<TH1F>("HSCPE_SystHUp", ";NCuts;HSCPE_SystHUp", NCuts, 0, NCuts);
-  tuple->HSCPE_SystHUp->Sumw2();
 
   tuple->HSCPE_SystHDown = dir.make<TH1F>("HSCPE_SystHDown", ";NCuts;HSCPE_SystHDown", NCuts, 0, NCuts);
-  tuple->HSCPE_SystHDown->Sumw2();
 
 
   tuple->Mass = dir.make<TH2F>("Mass", ";NCuts;Mass", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->Mass->Sumw2();
 
   tuple->MassTOF = dir.make<TH2F>("MassTOF", ";NCuts;MassTOF", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->MassTOF->Sumw2();
 
   tuple->MassComb = dir.make<TH2F>("MassComb", ";NCuts;MassComb", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->MassComb->Sumw2();
 
   tuple->MaxEventMass = dir.make<TH2F>("MaxEventMass", ";NCuts;MaxEventMass", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->MaxEventMass->Sumw2();
 
 
   tuple->Mass_SystP = dir.make<TH2F>("Mass_SystP", ";NCuts;Mass_SystP", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->Mass_SystP->Sumw2();
 
   tuple->MassTOF_SystP = dir.make<TH2F>("MassTOF_SystP", ";NCuts;MassTOF_SystP", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->MassTOF_SystP->Sumw2();
 
   tuple->MassComb_SystP = dir.make<TH2F>("MassComb_SystP", ";NCuts;MassComb_SystP", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->MassComb_SystP->Sumw2();
 
   tuple->MaxEventMass_SystP = dir.make<TH2F>("MaxEventMass_SystP", ";NCuts;MaxEventMass_SystP", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->MaxEventMass_SystP->Sumw2();
 
 
   tuple->Mass_SystI = dir.make<TH2F>("Mass_SystI", ";NCuts;Mass_SystI", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->Mass_SystI->Sumw2();
 
   tuple->MassTOF_SystI = dir.make<TH2F>("MassTOF_SystI", ";NCuts;MassTOF_SystI", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->MassTOF_SystI->Sumw2();
 
   tuple->MassComb_SystI = dir.make<TH2F>("MassComb_SystI", ";NCuts;MassComb_SystI", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->MassComb_SystI->Sumw2();
 
   tuple->MaxEventMass_SystI = dir.make<TH2F>("MaxEventMass_SystI", ";NCuts;MaxEventMass_SystI", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->MaxEventMass_SystI->Sumw2();
 
   tuple->Mass_SystM = dir.make<TH2F>("Mass_SystM", ";NCuts;Mass_SystM", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->Mass_SystM->Sumw2();
   tuple->MassTOF_SystM = dir.make<TH2F>("MassTOF_SystM", ";NCuts;MassTOF_SystM", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->MassTOF_SystM->Sumw2();
   tuple->MassComb_SystM = dir.make<TH2F>("MassComb_SystM", ";NCuts;MassComb_SystM", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->MassComb_SystM->Sumw2();
   tuple->MaxEventMass_SystM = dir.make<TH2F>("MaxEventMass_SystM", ";NCuts;MaxEventMass_SystM", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->MaxEventMass_SystM->Sumw2();
 
   tuple->Mass_SystT = dir.make<TH2F>("Mass_SystT", ";NCuts;Mass_SystT", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->Mass_SystT->Sumw2();
   tuple->MassTOF_SystT = dir.make<TH2F>("MassTOF_SystT", ";NCuts;MassTOF_SystT", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->MassTOF_SystT->Sumw2();
   tuple->MassComb_SystT = dir.make<TH2F>("MassComb_SystT", ";NCuts;MassComb_SystT", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->MassComb_SystT->Sumw2();
   tuple->MaxEventMass_SystT = dir.make<TH2F>("MaxEventMass_SystT", ";NCuts;MaxEventMass_SystT", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->MaxEventMass_SystT->Sumw2();
 
   tuple->Mass_SystPU = dir.make<TH2F>("Mass_SystPU", ";NCuts;Mass_SystPU", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->Mass_SystPU->Sumw2();
   tuple->MassTOF_SystPU = dir.make<TH2F>("MassTOF_SystPU", ";NCuts;MassTOF_SystPU", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->MassTOF_SystPU->Sumw2();
   tuple->MassComb_SystPU = dir.make<TH2F>("MassComb_SystPU", ";NCuts;MassComb_SystPU", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->MassComb_SystPU->Sumw2();
   tuple->MaxEventMass_SystPU = dir.make<TH2F>("MaxEventMass_SystPU", ";NCuts;MaxEventMass_SystPU", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->MaxEventMass_SystPU->Sumw2();
 
   tuple->Mass_SystHUp = dir.make<TH2F>("Mass_SystHUp", ";NCuts;Mass_SystHUp", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->Mass_SystHUp->Sumw2();
   tuple->MassTOF_SystH = dir.make<TH2F>("MassTOF_SystH", ";NCuts;MassTOF_SystH", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->MassTOF_SystH->Sumw2();
   tuple->MassComb_SystHUp = dir.make<TH2F>("MassComb_SystHUp", ";NCuts;MassComb_SystHUp", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->MassComb_SystHUp->Sumw2();
   tuple->MaxEventMass_SystHUp = dir.make<TH2F>("MaxEventMass_SystHUp", ";NCuts;MaxEventMass_SystHUp", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->MaxEventMass_SystHUp->Sumw2();
 
   tuple->Mass_SystHDown = dir.make<TH2F>("Mass_SystHDown", ";NCuts;Mass_SystHDown", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->Mass_SystHDown->Sumw2();
   tuple->MassComb_SystHDown = dir.make<TH2F>("MassComb_SystHDown", ";NCuts;MassComb_SystHDown", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->MassComb_SystHDown->Sumw2();
   tuple->MaxEventMass_SystHDown = dir.make<TH2F>("MaxEventMass_SystHDown", ";NCuts;MaxEventMass_SystHDown", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->MaxEventMass_SystHDown->Sumw2();
 
   tuple->Mass_Flip = dir.make<TH2F>("Mass_Flip", ";NCuts;Mass_Flip", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->Mass_Flip->Sumw2();
   tuple->MassTOF_Flip = dir.make<TH2F>("MassTOF_Flip", ";NCuts;MassTOF_Flip", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->MassTOF_Flip->Sumw2();
   tuple->MassComb_Flip = dir.make<TH2F>("MassComb_Flip", ";NCuts;MassComb_Flip", NCuts, 0, NCuts, MassNBins, 0, MassHistoUpperBound);
-  tuple->MassComb_Flip->Sumw2();
 
   if (SkipSelectionPlot)
     return;
 
   tuple->Gen_DecayLength = dir.make<TH1F>("Gen_DecayLength", "Gen_DecayLength", 1000, 0, 1000);
-  tuple->Gen_DecayLength->Sumw2();
   tuple->Beta_Gen = dir.make<TH1F>("Beta_Gen", "Beta_Gen", 100, 0, 1);
-  tuple->Beta_Gen->Sumw2();
   tuple->Beta_GenCharged = dir.make<TH1F>("Beta_GenChaged", "Beta_GenChaged", 20, 0, 1);
-  tuple->Beta_GenCharged->Sumw2();
   tuple->Beta_Triggered = dir.make<TH1F>("Beta_Triggered", "Beta_Triggered", 20, 0, 1);
-  tuple->Beta_Triggered->Sumw2();
 
   tuple->Beta_Matched = dir.make<TH1F>("Beta_Matched", "Beta_Matched", 20, 0, 1);
-  tuple->Beta_Matched->Sumw2();
   tuple->Beta_PreselectedA = dir.make<TH1F>("Beta_PreselectedA", "Beta_PreselectedA", 20, 0, 1);
-  tuple->Beta_PreselectedA->Sumw2();
   tuple->Beta_PreselectedB = dir.make<TH1F>("Beta_PreselectedB", "Beta_PreselectedB", 20, 0, 1);
-  tuple->Beta_PreselectedB->Sumw2();
   tuple->Beta_PreselectedC = dir.make<TH1F>("Beta_PreselectedC", "Beta_PreselectedC", 20, 0, 1);
-  tuple->Beta_PreselectedC->Sumw2();
 
 
   tuple->BefPreS_GenPtVsdRMinGen = dir.make<TH2F>("BefPreS_GenPtVsdRMinGen", "BefPreS_GenPtVsdRMinGen", 50, 0, PtHistoUpperBound, 100, 0., 1.);
-  tuple->BefPreS_GenPtVsdRMinGen->Sumw2();
   tuple->BefPreS_GendRMin = dir.make<TH1F>("BefPreS_GendRMin",";dR_min;Gen candidate",100,0.,5.);
-  tuple->BefPreS_GendRMin->Sumw2();
   tuple->BefPreS_GenPtVsdRMinGenPostCut = dir.make<TH2F>("BefPreS_GenPtVsdRMinGenPostCut", ";GenPt (GeV);dRMinGen (after cut)", 50, 0, PtHistoUpperBound, 50, 0., 0.05);
-  tuple->BefPreS_GenPtVsdRMinGenPostCut->Sumw2();
   tuple->BefPreS_GenPtVsGenMinPt = dir.make<TH2F>("BefPreS_GenPtVsGenMinPt", "BefPreS_GenPtVsGenMinPt", 50, 0, PtHistoUpperBound, 100, 0, 1.);
-  tuple->BefPreS_GenPtVsGenMinPt->Sumw2();
   tuple->BefPreS_GenPtVsRecoPt = dir.make<TH2F>("BefPreS_GenPtVsRecoPt", "BefPreS_GenPtVsRecoPt", 50, 0, PtHistoUpperBound, 50, 0, PtHistoUpperBound);
-  tuple->BefPreS_GenPtVsRecoPt->Sumw2();
 
   tuple->BefPreS_pfType = dir.make<TH1F>("BefPreS_pfType", "BefPreS_pfType", 9, 0, 9);
-  tuple->BefPreS_pfType->Sumw2();
 
   tuple->BefPreS_massT = dir.make<TH1F>("BefPreS_massT", "BefPreS_massT", 50, 0.0, 250.0);
-  tuple->BefPreS_massT->Sumw2();
 
   tuple->BefPreS_MiniRelIsoAll = dir.make<TH1F>("BefPreS_MiniRelIsoAll",";MiniRelIsoAll;Tracks/bin", 150, 0.0, 1.5);
-  tuple->BefPreS_MiniRelIsoAll->Sumw2();
   tuple->BefPreS_MiniRelIsoChg = dir.make<TH1F>("BefPreS_MiniRelIsoChg",";MiniRelIsoChg;Tracks/bin",  150, 0.0, 1.5);
-  tuple->BefPreS_MiniRelIsoChg->Sumw2();
 
   tuple->BefPreS_RecoPFMET = dir.make<TH1F>("BefPreS_RecoPFMET", "BefPreS_RecoPFMET",  200, 0.0, 2000.0);
-  tuple->BefPreS_RecoPFMET->Sumw2();
   tuple->BefPreS_RecoPFHT = dir.make<TH1F>("BefPreS_RecoPFHT", "BefPreS_RecoPFHT",  200, 0.0, 2000.0);
-  tuple->BefPreS_RecoPFHT->Sumw2();
   tuple->BefPreS_CaloNumJets = dir.make<TH1F>("BefPreS_CaloNumJets", ";Number of calo jets;Jets/bin",  70, 0.0, 70.0);
-  tuple->BefPreS_CaloNumJets->Sumw2();
 
   tuple->BefPreS_Chi2oNdof = dir.make<TH1F>("BefPreS_Chi2oNdof", "BefPreS_Chi2oNdof", 20, 0, 20);
-  tuple->BefPreS_Chi2oNdof->Sumw2();
   // This should just be a 2-bin plot where high-purity is not present = 0 or present = 1
   tuple->BefPreS_Qual = dir.make<TH1F>("BefPreS_Qual", "BefPreS_Qual", 20, -0.5, 1.5);
-  tuple->BefPreS_Qual->Sumw2();
   tuple->BefPreS_TNOH_PUA = dir.make<TH1F>("BefPreS_TNOH_PUA", "BefPreS_TNOH_PUA",  40, -0.5, 39.5);
-  tuple->BefPreS_TNOH_PUA->Sumw2();
   tuple->BefPreS_TNOH_PUB = dir.make<TH1F>("BefPreS_TNOH_PUB", "BefPreS_TNOH_PUB", 40, -0.5, 39.5);
-  tuple->BefPreS_TNOH_PUB->Sumw2();
   tuple->BefPreS_TNOHFraction = dir.make<TH1F>("BefPreS_TNOHFraction", "BefPreS_TNOHFraction", 50, 0., 1.);
-  tuple->BefPreS_TNOHFraction->Sumw2();
   tuple->BefPreS_TNOPH = dir.make<TH1F>("BefPreS_TNOPH",":Number of pixel hits", 8, -0.5, 7.5);
-  tuple->BefPreS_TNOPH->Sumw2();
   tuple->BefPreS_TNOHFractionTillLast = dir.make<TH1F>("BefPreS_TNOHFractionTillLast", "BefPreS_TNOHFractionTillLast", 50, 0, 1);
-  tuple->BefPreS_TNOHFractionTillLast->Sumw2();
   tuple->BefPreS_TNOMHTillLast = dir.make<TH1F>("BefPreS_TNOMHTillLast", "BefPreS_TNOMHTillLast", 20, 0, 20);
-  tuple->BefPreS_TNOMHTillLast->Sumw2();
   tuple->BefPreS_Eta = dir.make<TH1F>("BefPreS_Eta", ";#eta", 50, -2.6, 2.6);
-  tuple->BefPreS_Eta->Sumw2();
   tuple->BefPreS_TNOM = dir.make<TH1F>("BefPreS_TNOM",";Number of measurements", 40, -0.5, 39.5);
-  tuple->BefPreS_TNOM->Sumw2();
   tuple->BefPreS_TNOM_PUA = dir.make<TH1F>("BefPreS_TNOM_PUA",";Number of measurements (low PU)", 40, -0.5, 39.5);
-  tuple->BefPreS_TNOM_PUA->Sumw2();
   tuple->BefPreS_TNOM_PUB = dir.make<TH1F>("BefPreS_TNOM_PUB",";Number of measurements (high PU)", 40, -0.5, 39.5);
-  tuple->BefPreS_TNOM_PUB->Sumw2();
   tuple->BefPreS_nDof = dir.make<TH1F>("BefPreS_nDof",";Number of DF", 40, -0.5, 39.5);
-  tuple->BefPreS_nDof->Sumw2();
   tuple->BefPreS_TOFError = dir.make<TH1F>("BefPreS_TOFError", "BefPreS_TOFError", 25, 0, 0.25);
-  tuple->BefPreS_TOFError->Sumw2();
   tuple->BefPreS_PtErrOverPt = dir.make<TH1F>("BefPreS_PtErrOverPt", "BefPreS_PtErrOverPt", 40, 0, 1);
-  tuple->BefPreS_PtErrOverPt->Sumw2();
   tuple->BefPreS_PtErrOverPt2 = dir.make<TH1F>("BefPreS_PtErrOverPt2", "BefPreS_PtErrOverPt2", 40, 0, 0.003);
-  tuple->BefPreS_PtErrOverPt2->Sumw2();
   tuple->BefPreS_Pt = dir.make<TH1F>("BefPreS_Pt", ";p_{T} (GeV)", 50, 0, PtHistoUpperBound);
-  tuple->BefPreS_Pt->Sumw2();
   tuple->BefPreS_Pt_lowPt = dir.make<TH1F>("BefPreS_Pt_lowPt", ";p_{T} (GeV)", 50, 0, 500);
-  tuple->BefPreS_Pt_lowPt->Sumw2();
   tuple->BefPreS_Ias = dir.make<TH1F>("BefPreS_Ias", "BefPreS_Ias", 10, 0., 1.);
-  tuple->BefPreS_Ias->Sumw2();
   tuple->BefPreS_Ih = dir.make<TH1F>("BefPreS_Ih", "BefPreS_Ih", 200, 0, dEdxM_UpLim);
-  tuple->BefPreS_Ih->Sumw2();
   tuple->BefPreS_MTOF = dir.make<TH1F>("BefPreS_MTOF", "BefPreS_MTOF", 50, -2, 5);
-  tuple->BefPreS_MTOF->Sumw2();
   tuple->BefPreS_TIsol = dir.make<TH1F>("BefPreS_TIsol", "BefPreS_TIsol", 25, 0, 100);
-  tuple->BefPreS_TIsol->Sumw2();
   tuple->BefPreS_EoP = dir.make<TH1F>("BefPreS_EoP", "BefPreS_EoP", 25, 0, 1.5);
-  tuple->BefPreS_EoP->Sumw2();
   tuple->BefPreS_SumpTOverpT = dir.make<TH1F>("BefPreS_SumpTOverpT", "BefPreS_SumpTOverpT", 80, 0.0, 2.0);
-  tuple->BefPreS_SumpTOverpT->Sumw2();
   tuple->BefPreS_LastHitDXY = dir.make<TH1F>("BefPreS_LastHitDXY", "BefPreS_LastHitDXY", 75, 0, 150);
-  tuple->BefPreS_LastHitDXY->Sumw2();
   tuple->BefPreS_LastHitD3D = dir.make<TH1F>("BefPreS_LastHitD3D", "BefPreS_LastHitD3D", 175, 0, 350);
-  tuple->BefPreS_LastHitD3D->Sumw2();
   tuple->BefPreS_P = dir.make<TH1F>("BefPreS_P", "BefPreS_P", 50, 0, PtHistoUpperBound);
-  tuple->BefPreS_P->Sumw2();
   tuple->BefPreS_Pt = dir.make<TH1F>("BefPreS_Pt", "BefPreS_Pt", 50, 0, PtHistoUpperBound);
-  tuple->BefPreS_Pt->Sumw2();
   tuple->BefPreS_Pt_PUA = dir.make<TH1F>("BefPreS_Pt_PUA", "BefPreS_Pt_PUA", 50, 0, PtHistoUpperBound);
-  tuple->BefPreS_Pt_PUA->Sumw2();
   tuple->BefPreS_Pt_PUB = dir.make<TH1F>("BefPreS_Pt_PUB", "BefPreS_Pt_PUB", 50, 0, PtHistoUpperBound);
-  tuple->BefPreS_Pt_PUB->Sumw2();
   tuple->BefPreS_Pt_Cosmic = dir.make<TH1F>("BefPreS_Pt_Cosmic", "BefPreS_Pt_Cosmic", 50, 0, PtHistoUpperBound);
-  tuple->BefPreS_Pt_Cosmic->Sumw2();
   tuple->BefPreS_Pt_DT = dir.make<TH1F>("BefPreS_Pt_DT", "BefPreS_Pt_DT", 50, 0, PtHistoUpperBound);
-  tuple->BefPreS_Pt_DT->Sumw2();
   tuple->BefPreS_Pt_CSC = dir.make<TH1F>("BefPreS_Pt_CSC", "BefPreS_Pt_CSC", 50, 0, PtHistoUpperBound);
-  tuple->BefPreS_Pt_CSC->Sumw2();
   tuple->BefPreS_Ias = dir.make<TH1F>("BefPreS_Ias", "BefPreS_Ias", 100, 0, dEdxS_UpLim);
-  tuple->BefPreS_Ias->Sumw2();
   tuple->BefPreS_Ias_PUA = dir.make<TH1F>("BefPreS_Ias_PUA", "BefPreS_Ias_PUA", 100, 0, dEdxS_UpLim);
-  tuple->BefPreS_Ias_PUA->Sumw2();
   tuple->BefPreS_Ias_PUB = dir.make<TH1F>("BefPreS_Ias_PUB", "BefPreS_Ias_PUB", 100, 0, dEdxS_UpLim);
-  tuple->BefPreS_Ias_PUB->Sumw2();
   tuple->BefPreS_Ias_Cosmic = dir.make<TH1F>("BefPreS_Ias_Cosmic", "BefPreS_Ias_Cosmic", 100, 0, dEdxS_UpLim);
-  tuple->BefPreS_Ias_Cosmic->Sumw2();
   tuple->BefPreS_Ih_Cosmic = dir.make<TH1F>("BefPreS_Ih_Cosmic", "BefPreS_Ih_Cosmic", 200, 0, dEdxM_UpLim);
-  tuple->BefPreS_Ih_Cosmic->Sumw2();
   tuple->BefPreS_Ih = dir.make<TH1F>("BefPreS_Ih", "BefPreS_Ih", 200, 0, dEdxM_UpLim);
-  tuple->BefPreS_Ih->Sumw2();
   tuple->BefPreS_Ih_PUA = dir.make<TH1F>("BefPreS_Ih_PUA", "BefPreS_Ih_PUA", 200, 0, dEdxM_UpLim);
-  tuple->BefPreS_Ih_PUA->Sumw2();
   tuple->BefPreS_Ih_PUB = dir.make<TH1F>("BefPreS_Ih_PUB", "BefPreS_Ih_PUB", 200, 0, dEdxM_UpLim);
-  tuple->BefPreS_Ih_PUB->Sumw2();
   tuple->BefPreS_TOF = dir.make<TH1F>("BefPreS_TOF", "BefPreS_TOF", 150, -1, 5);
-  tuple->BefPreS_TOF->Sumw2();
   tuple->BefPreS_TOF_PUA = dir.make<TH1F>("BefPreS_TOF_PUA", "BefPreS_TOF_PUA", 150, -1, 5);
-  tuple->BefPreS_TOF_PUA->Sumw2();
   tuple->BefPreS_TOF_PUB = dir.make<TH1F>("BefPreS_TOF_PUB", "BefPreS_TOF_PUB", 150, -1, 5);
-  tuple->BefPreS_TOF_PUB->Sumw2();
   tuple->BefPreS_TOF_DT = dir.make<TH1F>("BefPreS_TOF_DT", "BefPreS_TOF_DT", 150, -1, 5);
-  tuple->BefPreS_TOF_DT->Sumw2();
   tuple->BefPreS_TOF_CSC = dir.make<TH1F>("BefPreS_TOF_CSC", "BefPreS_TOF_CSC", 150, -1, 5);
-  tuple->BefPreS_TOF_CSC->Sumw2();
   tuple->BefPreS_dR_NVTrack = dir.make<TH1F>("BefPreS_dR_NVTrack", "BefPreS_dR_NVTrack", 40, 0, 1);
-  tuple->BefPreS_dR_NVTrack->Sumw2();
   tuple->BefPreS_MatchedStations = dir.make<TH1F>("BefPreS_MatchedStations", "BefPreS_MatchedStations", 8, -0.5, 7.5);
-  tuple->BefPreS_MatchedStations->Sumw2();
   tuple->BefPreS_InnerInvPtDiff = dir.make<TH1F>("BefPreS_InnerInvPtDiff", "BefPreS_InnerInvPtDiff", 120, -4, 4);
-  tuple->BefPreS_InnerInvPtDiff->Sumw2();
   tuple->BefPreS_Phi = dir.make<TH1F>("BefPreS_Phi", "BefPreS_Phi", 50, -3.14, 3.14);
-  tuple->BefPreS_Phi->Sumw2();
   tuple->BefPreS_TimeAtIP = dir.make<TH1F>("BefPreS_TimeAtIP", "BefPreS_TimeAtIP", 50, -100, 100);
-  tuple->BefPreS_TimeAtIP->Sumw2();
   tuple->BefPreS_OpenAngle = dir.make<TH1F>("BefPreS_OpenAngle", "BefPreS_OpenAngle", 50, -0.3, 3.15);
-  tuple->BefPreS_OpenAngle->Sumw2();
   tuple->BefPreS_OpenAngle_Cosmic = dir.make<TH1F>("BefPreS_OpenAngle_Cosmic", "BefPreS_OpenAngle_Cosmic", 50, -0.3, 3.15);
-  tuple->BefPreS_OpenAngle_Cosmic->Sumw2();
 
   tuple->BefPreS_NVertex = dir.make<TH1F>("BefPreS_NVertex", "BefPreS_NVertex", 50, -0.5, 49.5);
-  tuple->BefPreS_NVertex->Sumw2();
   tuple->BefPreS_NVertex_NoEventWeight = dir.make<TH1F>("BefPreS_NVertex_NoEventWeight", "BefPreS_NVertex_NoEventWeight", 50, -0.5, 49.5);
-  tuple->BefPreS_NVertex_NoEventWeight->Sumw2();
   tuple->BefPreS_PV = dir.make<TH1F>("BefPreS_PV", "BefPreS_PV", 60, 0, 60);
-  tuple->BefPreS_PV->Sumw2();
   tuple->BefPreS_PV_NoEventWeight = dir.make<TH1F>("BefPreS_PV_NoEventWeight", "BefPreS_PV_NoEventWeight", 60, 0, 60);
-  tuple->BefPreS_PV_NoEventWeight->Sumw2();
   tuple->BefPreS_NOMoNOH = dir.make<TH1F>("BefPreS_NOMoNOH",";Num of measurment / num of hits;Tracks/bin",10,0.,1.0);
-  tuple->BefPreS_NOMoNOH->Sumw2();
   tuple->BefPreS_NOMoNOHvsPV = dir.make<TProfile>("BefPreS_NOMoNOHvsPV", "BefPreS_NOMoNOHvsPV", 60, 0, 60);
-  tuple->BefPreS_NOMoNOHvsPV->Sumw2();
   tuple->BefPreS_dzAll = dir.make<TH1F>("BefPreS_dzAll", "BefPreS_dzAll", 200, -10, 10);
-  tuple->BefPreS_dzAll->Sumw2();
   tuple->BefPreS_dxyAll = dir.make<TH1F>("BefPreS_dxyAll", "BefPreS_dxyAll", 200, -0.2, 0.2);
-  tuple->BefPreS_dxyAll->Sumw2();
   tuple->BefPreS_Dz = dir.make<TH1F>("BefPreS_Dz","d_{z} (cm)", 200, -0.3, 0.3);
-  tuple->BefPreS_Dz->Sumw2();
   tuple->BefPreS_Dxy = dir.make<TH1F>("BefPreS_Dxy","d_{xy} (cm)", 200, -0.1, 0.1);
-  tuple->BefPreS_Dxy->Sumw2();
 
   tuple->BefPreS_SegSep = dir.make<TH1F>("BefPreS_SegSep", "BefPreS_SegSep", 50, 0, 2.5);
-  tuple->BefPreS_SegSep->Sumw2();
   tuple->BefPreS_SegMinEtaSep = dir.make<TH1F>("BefPreS_SegMinEtaSep", "BefPreS_SegMinEtaSep", 50, -1., 1.);
-  tuple->BefPreS_SegMinEtaSep->Sumw2();
   tuple->BefPreS_SegMinPhiSep = dir.make<TH1F>("BefPreS_SegMinPhiSep", "BefPreS_SegMinPhiSep", 50, -3.3, 3.3);
-  tuple->BefPreS_SegMinPhiSep->Sumw2();
   tuple->BefPreS_SegMinEtaSep_FailDz = dir.make<TH1F>("BefPreS_SegMinEtaSep_FailDz", "BefPreS_SegMinEtaSep_FailDz", 50, -1., 1.);
-  tuple->BefPreS_SegMinEtaSep_FailDz->Sumw2();
   tuple->BefPreS_SegMinEtaSep_PassDz = dir.make<TH1F>("BefPreS_SegMinEtaSep_PassDz", "BefPreS_SegMinEtaSep_PassDz", 50, -1., 1.);
-  tuple->BefPreS_SegMinEtaSep_PassDz->Sumw2();
   tuple->BefPreS_Dz_FailSep = dir.make<TH1F>("BefPreS_Dz_FailSep", "BefPreS_Dz_FailSep", 50, -150, 150);
-  tuple->BefPreS_Dz_FailSep->Sumw2();
 
   tuple->BefPreS_Dxy_Cosmic = dir.make<TH1F>("BefPreS_Dxy_Cosmic", "BefPreS_Dxy_Cosmic", 150, -IPbound, IPbound);
-  tuple->BefPreS_Dxy_Cosmic->Sumw2();
   tuple->BefPreS_Dz_Cosmic = dir.make<TH1F>("BefPreS_Dz_Cosmic", "BefPreS_Dz_Cosmic", 150, -IPbound, IPbound);
-  tuple->BefPreS_Dz_Cosmic->Sumw2();
   tuple->BefPreS_Dz_CSC = dir.make<TH1F>("BefPreS_Dz_CSC", "BefPreS_Dz_CSC", 150, -IPbound, IPbound);
-  tuple->BefPreS_Dz_CSC->Sumw2();
   tuple->BefPreS_Dz_DT = dir.make<TH1F>("BefPreS_Dz_DT", "BefPreS_Dz_DT", 150, -IPbound, IPbound);
-  tuple->BefPreS_Dz_DT->Sumw2();
   tuple->BefPreS_Pt_FailDz = dir.make<TH1F>("BefPreS_Pt_FailDz", "BefPreS_Pt_FailDz", 50, 0, PtHistoUpperBound);
-  tuple->BefPreS_Pt_FailDz->Sumw2();
   tuple->BefPreS_Pt_FailDz_DT = dir.make<TH1F>("BefPreS_Pt_FailDz_DT", "BefPreS_Pt_FailDz_DT", 50, 0, PtHistoUpperBound);
-  tuple->BefPreS_Pt_FailDz_DT->Sumw2();
   tuple->BefPreS_Pt_FailDz_CSC = dir.make<TH1F>("BefPreS_Pt_FailDz_CSC", "BefPreS_Pt_FailDz_CSC", 50, 0, PtHistoUpperBound);
-  tuple->BefPreS_Pt_FailDz_CSC->Sumw2();
   tuple->BefPreS_TOF_FailDz = dir.make<TH1F>("BefPreS_TOF_FailDz", "BefPreS_TOF_FailDz", 150, -1, 5);
-  tuple->BefPreS_TOF_FailDz->Sumw2();
   tuple->BefPreS_TOF_FailDz_DT = dir.make<TH1F>("BefPreS_TOF_FailDz_DT", "BefPreS_TOF_FailDz_DT", 150, -1, 5);
-  tuple->BefPreS_TOF_FailDz_DT->Sumw2();
   tuple->BefPreS_TOF_FailDz_CSC = dir.make<TH1F>("BefPreS_TOF_FailDz_CSC", "BefPreS_TOF_FailDz_CSC", 150, -1, 5);
-  tuple->BefPreS_TOF_FailDz_CSC->Sumw2();
   tuple->BefPreS_GenPtVsRecoPt = dir.make<TH2F>("BefPreS_GenPtVsRecoPt", "BefPreS_GenPtVsRecoPt", 50, 0, PtHistoUpperBound, 50, 0, PtHistoUpperBound);
-  tuple->BefPreS_GenPtVsRecoPt->Sumw2();
   tuple->BefPreS_PtErrOverPtVsPtErrOverPt2 = dir.make<TH2F>("BefPreS_PtErrOverPtVsPtErrOverPt2", "BefPreS_PtErrOverPtVsPtErrOverPt2",  40, 0., 1., 40, 0., 0.003);
-  tuple->BefPreS_PtErrOverPtVsPtErrOverPt2->Sumw2();
   tuple->BefPreS_PtErrOverPtVsPt = dir.make<TH2F>("BefPreS_PtErrOverPtVsPt", "BefPreS_PtErrOverPtVsPt",  40, 0., 1., 40, 0., 4000);
-  tuple->BefPreS_PtErrOverPtVsPt->Sumw2();
   
   tuple->BefPreS_ProbQ = dir.make<TH1F>("BefPreS_ProbQ", "BefPreS_ProbQ", 100, 0, 1);
-  tuple->BefPreS_ProbQ->Sumw2();
   tuple->BefPreS_ProbXY = dir.make<TH1F>("BefPreS_ProbXY", "BefPreS_ProbXY", 100, 0, 1);
-  tuple->BefPreS_ProbXY->Sumw2();
   tuple->BefPreS_ProbQNoL1 = dir.make<TH1F>("BefPreS_ProbQNoL1", "BefPreS_ProbQNoL1", 100, 0, 1);
-  tuple->BefPreS_ProbQNoL1->Sumw2();
   tuple->BefPreS_ProbXYNoL1 = dir.make<TH1F>("BefPreS_ProbXYNoL1", "BefPreS_ProbXYNoL1", 100, 0, 1);
-  tuple->BefPreS_ProbXYNoL1->Sumw2();
   tuple->BefPreS_MassErr = dir.make<TH1F>("BefPreS_MassErr", "BefPreS_MassErr", 50, 0., 10.);
-  tuple->BefPreS_MassErr->Sumw2();
   tuple->BefPreS_ProbQVsIas = dir.make<TH2F>("BefPreS_ProbQVsIas", "BefPreS_ProbQVsIas", 100, 0.0, 1.0, 100, 0.0, 1.0);
-  tuple->BefPreS_ProbQVsIas->Sumw2();
   
   tuple->BefPreS_EtaVsIas = dir.make<TH2F>("BefPreS_EtaVsIas", "BefPreS_EtaVsIas", 50, -3, 3, 10, 0., 1.);
   tuple->BefPreS_EtaVsIh = dir.make<TH2F>("BefPreS_EtaVsIh", "BefPreS_EtaVsIh", 50, -3, 3, 100, 0, dEdxM_UpLim);
@@ -691,562 +524,302 @@ void TupleMaker::initializeTuple(Tuple *&tuple,
   tuple->BefPreS_TOFIh = dir.make<TH2F>("BefPreS_TOFIh", "BefPreS_TOFIh", 50, 0, 5, 100, 0, dEdxM_UpLim);
 
   tuple->BefPreS_CluProbQVsPixelLayer = dir.make<TH2F>("BefPreS_CluProbQVsPixelLayer",";CluProbQ;Layer",20,0.,1.,4,0.,4.);
-  tuple->BefPreS_CluProbQVsPixelLayer->Sumw2();
   tuple->BefPreS_CluProbXYVsPixelLayer = dir.make<TH2F>("BefPreS_CluProbXYVsPixelLayer",";CluProbXY;Layer",100,0.,1.,4,0.,4.);
-  tuple->BefPreS_CluProbXYVsPixelLayer->Sumw2();
   tuple->BefPreS_CluNormChargeVsPixelLayer = dir.make<TH2F>("BefPreS_CluNormChargeVsPixelLayer",";CluNormCharge;Layer",100,0.,600.,4,0.,4.);
-  tuple->BefPreS_CluNormChargeVsPixelLayer->Sumw2();
   tuple->BefPreS_CluNormChargeVsPixelLayer_lowBetaGamma = dir.make<TH2F>("BefPreS_CluNormChargeVsPixelLayer_lowBetaGamma",";CluNormCharge;Layer",100,0.,600.,4,0.,4.);
-  tuple->BefPreS_CluNormChargeVsPixelLayer_lowBetaGamma->Sumw2();
   tuple->BefPreS_CluSizeVsPixelLayer = dir.make<TH2F>("BefPreS_CluSizeVsPixelLayer",";CluSize;Layer",10,0.,10.,4,0.,4.);
-  tuple->BefPreS_CluSizeVsPixelLayer->Sumw2();
   tuple->BefPreS_CluSizeXVsPixelLayer = dir.make<TH2F>("BefPreS_CluSizeXVsPixelLayer",";CluSizeX;Layer",10,0.,10.,4,0.,4.);
-  tuple->BefPreS_CluSizeXVsPixelLayer->Sumw2();
   tuple->BefPreS_CluSizeYVsPixelLayer = dir.make<TH2F>("BefPreS_CluSizeYVsPixelLayer",";CluSizeY;Layer",10,0.,10.,4,0.,4.);
-  tuple->BefPreS_CluSizeYVsPixelLayer->Sumw2();
   tuple->BefPreS_CluSpecInCPEVsPixelLayer = dir.make<TH2F>("BefPreS_CluSpecInCPEVsPixelLayer",";CluSpecInCPE;Layer",4,0.,4.,4,0.,4.);
-  tuple->BefPreS_CluSpecInCPEVsPixelLayer->Sumw2();
 
   tuple->BefPreS_CluCotBetaVsPixelLayer_lowProbXY = dir.make<TH2F>("BefPreS_CluCotBetaVsPixelLayer_lowProbXY",";CotBeta;Layer",200,-10.,10.,4,0.,4.);
-  tuple->BefPreS_CluCotBetaVsPixelLayer_lowProbXY->Sumw2();
   tuple->BefPreS_CluCotAlphaVsPixelLayer_lowProbXY = dir.make<TH2F>("BefPreS_CluCotAlphaVsPixelLayer_lowProbXY",";CotAlpha;Layer",100,-1.,1.,4,0.,4.);
-  tuple->BefPreS_CluCotAlphaVsPixelLayer_lowProbXY->Sumw2();
   tuple->BefPreS_CluCotBetaVsPixelLayer = dir.make<TH2F>("BefPreS_CluCotBetaVsPixelLayer",";CotBeta;Layer",200,-10.,10.,4,0.,4.);
-  tuple->BefPreS_CluCotBetaVsPixelLayer->Sumw2();
   tuple->BefPreS_CluCotAlphaVsPixelLayer = dir.make<TH2F>("BefPreS_CluCotAlphaVsPixelLayer",";CotAlpha;Layer",100,-1.,1.,4,0.,4.);
-  tuple->BefPreS_CluCotAlphaVsPixelLayer->Sumw2();
 
   tuple->BefPreS_CluNormChargeVsStripLayer_lowBetaGamma = dir.make<TH2F>("BefPreS_CluNormChargeVsStripLayer_lowBetaGamma",";CluNormCharge;Layer",600,0.,600.,20,0.,20.);
-  tuple->BefPreS_CluNormChargeVsStripLayer_lowBetaGamma->Sumw2();
   tuple->BefPreS_CluNormChargeVsStripLayer_higherBetaGamma = dir.make<TH2F>("BefPreS_CluNormChargeVsStripLayer_higherBetaGamma",";CluNormCharge;Layer",600,0.,600.,20,0.,20.);
-  tuple->BefPreS_CluNormChargeVsStripLayer_higherBetaGamma->Sumw2();
   tuple->BefPreS_CluNormChargeVsStripLayer_higherBetaGamma_Stat91 = dir.make<TH2F>("BefPreS_CluNormChargeVsStripLayer_higherBetaGamma_Stat91",";CluNormCharge;Layer",600,0.,600.,20,0.,20.);
-  tuple->BefPreS_CluNormChargeVsStripLayer_higherBetaGamma_Stat91->Sumw2();
   tuple->BefPreS_CluNormChargeVsStripLayer_higherBetaGamma_StatNot91 = dir.make<TH2F>("BefPreS_CluNormChargeVsStripLayer_higherBetaGamma_StatNot91",";CluNormCharge;Layer",600,0.,600.,20,0.,20.);
-  tuple->BefPreS_CluNormChargeVsStripLayer_higherBetaGamma_StatNot91->Sumw2();
   tuple->BefPreS_CluNormChargeVsStripLayer_higherBetaGamma_StatHigherThan2 = dir.make<TH2F>("BefPreS_CluNormChargeVsStripLayer_higherBetaGamma_StatHigherThan2",";CluNormCharge;Layer",600,0.,600.,20,0.,20.);
-  tuple->BefPreS_CluNormChargeVsStripLayer_higherBetaGamma_StatHigherThan2->Sumw2();
 
   tuple->BefPreS_dRMinPfJet= dir.make<TH1F>("BefPreS_dRMinPfJet",";dRMinPfJet",100,0.,1.5);
-  tuple->BefPreS_dRMinPfJet->Sumw2();
   tuple->BefPreS_dRMinPfJetVsIas =  dir.make<TH2F>("BefPreS_dRMinPfJetVsIas",";dRMinPfJet;Ias",100,0.,1.5,10,0.,1.);
-  tuple->BefPreS_dRMinPfJetVsIas->Sumw2();
   tuple->BefPreS_dRMinCaloJet= dir.make<TH1F>("BefPreS_dRMinCaloJet",";dRMinCaloJet",100,0.,1.5);
-  tuple->BefPreS_dRMinCaloJet->Sumw2();
   tuple->BefPreS_dRMinCaloJetVsIas =  dir.make<TH2F>("BefPreS_dRMinCaloJetVsIas",";dRMinCaloJet;Ias",100,0.,1.5,10,0.,1.);
-  tuple->BefPreS_dRMinCaloJetVsIas->Sumw2();
   tuple->BefPreS_genGammaBetaVsProbXYNoL1 =  dir.make<TH2F>("BefPreS_genGammaBetaVsProbXYNoL1", ";#gamma #beta;ProbXYNoL1",10,0.,1.3,20,0.,1.);
-  tuple->BefPreS_genGammaBetaVsProbXYNoL1->Sumw2();
   tuple->BefPreS_dRVsPtPfJet = dir.make<TH2F>("BefPreS_dRVsPtPfJet",";dR(cand,jet);p_{T}",100,0.,1.5,100,0.,1000.);
-  tuple->BefPreS_dRVsPtPfJet->Sumw2();
   tuple->BefPreS_dRVsdPtPfCaloJet = dir.make<TH2F>("BefPreS_dRVsdPtPfCaloJet",";dRmin;dPtPfCaloJet",100,0.,1.5,20,0.,100.);
-  tuple->BefPreS_dRVsdPtPfCaloJet->Sumw2();
   
 
   tuple->PostPreS_TriggerType = dir.make<TH1F>("PostPreS_TriggerType", "PostPreS_TriggerType", 3, 0., 3.);
-  tuple->PostPreS_TriggerType->Sumw2();
 
   tuple->PostPreS_pfType = dir.make<TH1F>("PostPreS_pfType", "PostPreS_pfType", 9, 0, 9);
-  tuple->PostPreS_pfType->Sumw2();
   tuple->PostPreS_pfTypeVsIas = dir.make<TH2F>("PostPreS_pfTypeVsIas","PostPreS_pfTypeVsIas", 9, 0, 9.,20,0.,1.);
-  tuple->PostPreS_pfTypeVsIas->Sumw2();
 
   tuple->PostPreS_massT = dir.make<TH1F>("PostPreS_massT", "PostPreS_massT", 50, 0.0, 250.0);
-  tuple->PostPreS_massT->Sumw2();
   tuple->PostPreS_massTVsIas = dir.make<TH2F>("PostPreS_massTVsIas","PostPreS_massTVsIas",50, 0.0, 250.0, 20, 0., 1.);
-  tuple->PostPreS_massTVsIas->Sumw2();
   
   tuple->PostPreS_MiniRelIsoAll = dir.make<TH1F>("PostPreS_MiniRelIsoAll",";MiniRelIsoAll;Tracks/bin", 150, 0.0, 1.5);
-  tuple->PostPreS_MiniRelIsoAll->Sumw2();
   tuple->PostPreS_MiniRelIsoAllVsIas =  dir.make<TH2F>("PostPreS_MiniRelIsoAllVsIas","PostPreS_MiniRelIsoAllVsIas", 150, 0.0, 1.5, 10, 0.,1.);
-  tuple->PostPreS_MiniRelIsoAllVsIas->Sumw2();
   tuple->PostPreS_MiniRelIsoChg = dir.make<TH1F>("PostPreS_MiniRelIsoChg",";MiniRelIsoChg;Tracks/bin",  150, 0.0, 1.5);
-  tuple->PostPreS_MiniRelIsoChg->Sumw2();
   
   tuple->PostPreS_RecoPFMET = dir.make<TH1F>("PostPreS_RecoPFMET", "PostPreS_RecoPFMET",  200, 0.0, 2000.0);
-  tuple->PostPreS_RecoPFMET->Sumw2();
   tuple->PostPreS_RecoPFHT = dir.make<TH1F>("PostPreS_RecoPFHT", "PostPreS_RecoPFHT",  200, 0.0, 2000.0);
-  tuple->PostPreS_RecoPFHT->Sumw2();
   tuple->PostPreS_CaloNumJets = dir.make<TH1F>("PostPreS_CaloNumJets",";Number of calo jets;Jets/bin",  30, 0.0, 30.0);
-  tuple->PostPreS_CaloNumJets->Sumw2();
   
   tuple->PostPreS_Chi2oNdof = dir.make<TH1F>("PostPreS_Chi2oNdof", ";#chi^2/Ndof", 20, 0, 20);
-  tuple->PostPreS_Chi2oNdof->Sumw2();
   tuple->PostPreS_Chi2oNdofVsIas = dir.make<TH2F>("PostPreS_Chi2oNdofVsIas",";#chi^2/Ndof;I_{as}",20, 0, 20,10,0.,1.);
-  tuple->PostPreS_Chi2oNdofVsIas->Sumw2();
   tuple->PostPreS_Qual = dir.make<TH1F>("PostPreS_Qual","PostPreS_Qual", 20, -0.5, 19.5);
-  tuple->PostPreS_Qual->Sumw2();
   tuple->PostPreS_TNOH_PUA = dir.make<TH1F>("PostPreS_TNOH_PUA", "Number of hits (low PU)", 40, -0.5, 39.5);
-  tuple->PostPreS_TNOH_PUA->Sumw2();
   tuple->PostPreS_TNOH_PUB = dir.make<TH1F>("PostPreS_TNOH_PUB", "Number of hits (high PU)", 40, -0.5, 39.5);
-  tuple->PostPreS_TNOH_PUB->Sumw2();
   tuple->PostPreS_TNOHFraction = dir.make<TH1F>("PostPreS_TNOHFraction", ";TNOHFraction", 20, 0, 1);
-  tuple->PostPreS_TNOHFraction->Sumw2();
   tuple->PostPreS_TNOHFractionVsIas = dir.make<TH2F>("PostPreS_TNOHFractionVsIas","PostPreS_TNOHFractionVsIas",50, 0, 1,10,0.,1.);
-  tuple->PostPreS_TNOHFractionVsIas->Sumw2();
   tuple->PostPreS_TNOPH = dir.make<TH1F>( "PostPreS_TNOPH",";Number of pixel hits", 8, -0.5, 7.5);
-  tuple->PostPreS_TNOPH->Sumw2();
   tuple->PostPreS_TNOPHVsIas = dir.make<TH2F>("PostPreS_TNOPHVsIas",";_TNOPH;I_{as} ", 8,-0.5, 7.5, 20, 0., 1.);
-  tuple->PostPreS_TNOPHVsIas->Sumw2();
   tuple->PostPreS_TNOHFractionTillLast = dir.make<TH1F>("PostPreS_TNOHFractionTillLast", ";TNOHFractionTillLast", 50, 0, 1);
-  tuple->PostPreS_TNOHFractionTillLast->Sumw2();
   tuple->PostPreS_TNOMHTillLast = dir.make<TH1F>("PostPreS_TNOMHTillLast",";TNOMHTillLast", 20, -0.5, 19.5);
-  tuple->PostPreS_TNOMHTillLast->Sumw2();
   tuple->PostPreS_Eta = dir.make<TH1F>("PostPreS_Eta", ";#eta", 50, -2.6, 2.6);
-  tuple->PostPreS_Eta->Sumw2();
   tuple->PostPreS_EtaVsIas =  dir.make<TH2F>("PostPreS_EtaVsIas",";#eta;I_{as}", 50, -2.6, 2.6, 20,0.,1.);
-  tuple->PostPreS_EtaVsIas->Sumw2();
   tuple->PostPreS_TNOM = dir.make<TH1F>("PostPreS_TNOM",";Number of measurement", 40, -0.5, 39.5);
-  tuple->PostPreS_TNOM->Sumw2();
   tuple->PostPreS_TNOMVsIas = dir.make<TH2F>("PostPreS_TNOMVsIas",";Number of measurement;I_{as}",  40, -0.5, 39.5, 20, 0., 1.);
-  tuple->PostPreS_TNOMVsIas->Sumw2();
   tuple->PostPreS_TNOM_PUA = dir.make<TH1F>("PostPreS_TNOM_PUA",  ";Number of measurement (low PU)", 40, -0.5, 39.5);
-  tuple->PostPreS_TNOM_PUA->Sumw2();
   tuple->PostPreS_TNOM_PUB = dir.make<TH1F>("PostPreS_TNOM_PUB",  ";Number of measurement (high PU)",  40, -0.5, 39.5);
-  tuple->PostPreS_TNOM_PUB->Sumw2();
   tuple->PostPreS_nDof = dir.make<TH1F>("PostPreS_nDof", ";nDof",  40, -0.5, 39.5);
-  tuple->PostPreS_nDof->Sumw2();
   tuple->PostPreS_TOFError = dir.make<TH1F>("PostPreS_TOFError", "PostPreS_TOFError", 25, 0, 0.25);
-  tuple->PostPreS_TOFError->Sumw2();
   tuple->PostPreS_PtErrOverPt = dir.make<TH1F>("PostPreS_PtErrOverPt", "PostPreS_PtErrOverPt", 40, 0, 1);
-  tuple->PostPreS_PtErrOverPt->Sumw2();
   tuple->PostPreS_PtErrOverPtVsIas =  dir.make<TH2F>("PostPreS_PtErrOverPtVsIas","PostPreS_PtErrOverPtVsIas", 40, 0, 1, 20, 0.,1.);
-  tuple->PostPreS_PtErrOverPtVsIas->Sumw2();
   tuple->PostPreS_PtErrOverPt2 = dir.make<TH1F>("PostPreS_PtErrOverPt2", "PostPreS_PtErrOverPt2", 40, 0, 0.003);
-  tuple->PostPreS_PtErrOverPt2->Sumw2();
   tuple->PostPreS_Pt = dir.make<TH1F>("PostPreS_Pt", ";p_{T} (GeV)", 50, 0, PtHistoUpperBound);
-  tuple->PostPreS_Pt->Sumw2();
   tuple->PostPreS_Pt_lowPt = dir.make<TH1F>("PostPreS_Pt_lowPt",";p_{T} (GeV)", 50, 0, 500);
-  tuple->PostPreS_Pt_lowPt->Sumw2();
   tuple->PostPreS_PtVsIas = dir.make<TH2F>("PostPreS_PtVsIas","PostPreS_PtVsIas", 50, 0, PtHistoUpperBound, 20, 0., 1.);
-  tuple->PostPreS_PtVsIas->Sumw2();
   tuple->PostPreS_Ias = dir.make<TH1F>("PostPreS_Ias", "PostPreS_Ias", 10, 0, dEdxS_UpLim);
-  tuple->PostPreS_Ias->Sumw2();
   tuple->PostPreS_Ias_NoEventWeight = dir.make<TH1F>("PostPreS_Ias_NoEventWeight", "PostPreS_Ias_NoEventWeight", 10, 0, dEdxS_UpLim);
-  tuple->PostPreS_Ias_NoEventWeight->Sumw2();
   tuple->PostPreS_Ih = dir.make<TH1F>("PostPreS_Ih", "PostPreS_Ih", 200, 0, dEdxM_UpLim);
-  tuple->PostPreS_Ih->Sumw2();
   tuple->PostPreS_IhVsIas = dir.make<TH2F>("PostPreS_IhVsIas","PostPreS_IhVsIas",200, 0, dEdxM_UpLim, 20, 0.,1.);
-  tuple->PostPreS_IhVsIas->Sumw2();
   tuple->PostPreS_Ih_NoEventWeight = dir.make<TH1F>("PostPreS_Ih_NoEventWeight", "PostPreS_Ih_NoEventWeight", 200, 0, dEdxM_UpLim);
-  tuple->PostPreS_Ih_NoEventWeight->Sumw2();
   tuple->PostPreS_MTOF = dir.make<TH1F>("PostPreS_MTOF", "PostPreS_MTOF", 50, -2, 5);
-  tuple->PostPreS_MTOF->Sumw2();
   tuple->PostPreS_TIsol = dir.make<TH1F>("PostPreS_TIsol", "PostPreS_TIsol", 25, 0, 100);
-  tuple->PostPreS_TIsol->Sumw2();
   tuple->PostPreS_TIsolVsIas = dir.make<TH2F>("PostPreS_TIsolVsIas","PostPreS_TIsolVsIas",25, 0, 100, 10, 0., 1.);
-  tuple->PostPreS_TIsolVsIas->Sumw2();
   tuple->PostPreS_EoP = dir.make<TH1F>("PostPreS_EoP", "PostPreS_EoP", 25, 0, 1.5);
-  tuple->PostPreS_EoP->Sumw2();
   tuple->PostPreS_EoPVsIas = dir.make<TH2F>("PostPreS_EoPVsIas","PostPreS_EoPVsIas;E/ p;Ias",25, 0, 1.5, 20, 0.,1.);
-  tuple->PostPreS_EoPVsIas->Sumw2();
   tuple->PostPreS_SumpTOverpT = dir.make<TH1F>("PostPreS_SumpTOverpT", "PostPreS_SumpTOverpT", 80, 0.0, 2.0);
-  tuple->PostPreS_SumpTOverpT->Sumw2();
   tuple->PostPreS_SumpTOverpTVsIas = dir.make<TH2F>("PostPreS_SumpTOverpTVsIas","PostPreS_SumpTOverpTVsIas;SumpTOverpT;Ias", 80, 0.0, 2.0, 20, 0.,1.);
-  tuple->PostPreS_SumpTOverpTVsIas->Sumw2();
   tuple->PostPreS_LastHitDXY = dir.make<TH1F>("PostPreS_LastHitDXY", "PostPreS_LastHitDXY", 75, 0, 150);
-  tuple->PostPreS_LastHitDXY->Sumw2();
   tuple->PostPreS_LastHitDXYVsEta  = dir.make<TH2F>("PostPreS_LastHitDXYVsEta","PostPreS_LastHitDXYVsEta;LastHitDXY;Eta", 75, 0, 150, 20, 0.,1.);
-  tuple->PostPreS_LastHitDXYVsEta->Sumw2();
   tuple->PostPreS_LastHitD3D = dir.make<TH1F>("PostPreS_LastHitD3D", "PostPreS_LastHitD3D", 175, 0, 350);
-  tuple->PostPreS_LastHitD3D->Sumw2();
   tuple->PostPreS_LastHitD3DVsEta = dir.make<TH2F>("PostPreS_LastHitD3DVsEta","PostPreS_LastHitD3DVsEta;LastHitD3D;Eta", 175, 0, 350, 20, 0.,1.);
-  tuple->PostPreS_LastHitD3DVsEta->Sumw2();
   tuple->PostPreS_P = dir.make<TH1F>("PostPreS_P", ";Momentum (GeV)", 50, 0, PtHistoUpperBound);
-  tuple->PostPreS_P->Sumw2();
   tuple->PostPreS_dR_NVTrack = dir.make<TH1F>("PostPreS_dR_NVTrack", "PostPreS_dR_NVTrack", 40, 0, 1);
-  tuple->PostPreS_dR_NVTrack->Sumw2();
   tuple->PostPreS_MatchedStations = dir.make<TH1F>("PostPreS_MatchedStations",";MatchedStations",8, -0.5, 7.5);
-  tuple->PostPreS_MatchedStations->Sumw2();
   tuple->PostPreS_InnerInvPtDiff = dir.make<TH1F>("PostPreS_InnerInvPtDiff", "PostPreS_InnerInvPtDiff", 120, -4, 4);
-  tuple->PostPreS_InnerInvPtDiff->Sumw2();
   tuple->PostPreS_Phi = dir.make<TH1F>("PostPreS_Phi", "PostPreS_Phi", 50, -3.14, 3.14);
-  tuple->PostPreS_Phi->Sumw2();
   tuple->PostPreS_TimeAtIP = dir.make<TH1F>("PostPreS_TimeAtIP", "PostPreS_TimeAtIP", 50, -100, 100);
-  tuple->PostPreS_TimeAtIP->Sumw2();
   tuple->PostPreS_OpenAngle = dir.make<TH1F>("PostPreS_OpenAngle", "PostPreS_OpenAngle", 50, -0.3, 3.15);
-  tuple->PostPreS_OpenAngle->Sumw2();
   tuple->PostPreS_OpenAngle_Cosmic = dir.make<TH1F>("PostPreS_OpenAngle_Cosmic", "PostPreS_OpenAngle_Cosmic", 50, -0.3, 3.15);
-  tuple->PostPreS_OpenAngle_Cosmic->Sumw2();
   
   tuple->PostPreS_NVertex = dir.make<TH1F>("PostPreS_NVertex",";N_{vertex}", 50, -0.5, 49.5);
-  tuple->PostPreS_NVertex->Sumw2();
   tuple->PostPreS_NVertex_NoEventWeight = dir.make<TH1F>("PostPreS_NVertex_NoEventWeight",";N_{vertex} (NoEventWeight)", 50, -0.5, 49.5);
-  tuple->PostPreS_NVertex_NoEventWeight->Sumw2();
   tuple->PostPreS_PV = dir.make<TH1F>("PostPreS_PV",";PV", 60, -0.5, 59.5);
-  tuple->PostPreS_PV->Sumw2();
   tuple->PostPreS_PV_NoEventWeight = dir.make<TH1F>("PostPreS_PV_NoEventWeight", "PostPreS_PV_NoEventWeight", 60, 0, 60);
-  tuple->PostPreS_PV_NoEventWeight->Sumw2();
   tuple->PostPreS_NOMoNOH = dir.make<TH1F>("PostPreS_NOMoNOH",";Num of measurment / num of hits;Tracks/bin",10,0.,1.0);
-  tuple->PostPreS_NOMoNOH->Sumw2();
   tuple->PostPreS_NOMoNOHvsPV = dir.make<TProfile>("PostPreS_NOMoNOHvsPV", "PostPreS_NOMoNOHvsPV", 60, 0, 60);
-  tuple->PostPreS_NOMoNOHvsPV->Sumw2();
   tuple->PostPreS_dzAll = dir.make<TH1F>("PostPreS_dzAll", "PostPreS_dzAll", 200, -10, 10);
-  tuple->PostPreS_dzAll->Sumw2();
   tuple->PostPreS_dxyAll = dir.make<TH1F>("PostPreS_dxyAll", "PostPreS_dxyAll", 200, -0.2, 0.2);
-  tuple->PostPreS_dxyAll->Sumw2();
   tuple->PostPreS_Dz = dir.make<TH1F>( "PostPreS_Dz", ";dz (cm)", 200, -0.3, 0.3);
-  tuple->PostPreS_Dz->Sumw2();
   tuple->PostPreS_Dxy = dir.make<TH1F>("PostPreS_Dxy", "PostPreS_Dxy", 200, -0.1, 0.1);
-  tuple->PostPreS_Dxy->Sumw2();
   
   tuple->PostPreS_SegSep = dir.make<TH1F>("PostPreS_SegSep", "PostPreS_SegSep", 50, 0, 2.5);
-  tuple->PostPreS_SegSep->Sumw2();
   tuple->PostPreS_SegMinEtaSep = dir.make<TH1F>("PostPreS_SegMinEtaSep", "PostPreS_SegMinEtaSep", 50, -1., 1.);
-  tuple->PostPreS_SegMinEtaSep->Sumw2();
   tuple->PostPreS_SegMinPhiSep = dir.make<TH1F>("PostPreS_SegMinPhiSep", "PostPreS_SegMinPhiSep", 50, -3.3, 3.3);
-  tuple->PostPreS_SegMinPhiSep->Sumw2();
   tuple->PostPreS_SegMinEtaSep_FailDz = dir.make<TH1F>("PostPreS_SegMinEtaSep_FailDz", "PostPreS_SegMinEtaSep_FailDz", 50, -1., 1.);
-  tuple->PostPreS_SegMinEtaSep_FailDz->Sumw2();
   tuple->PostPreS_SegMinEtaSep_PassDz = dir.make<TH1F>("PostPreS_SegMinEtaSep_PassDz", "PostPreS_SegMinEtaSep_PassDz", 50, -1., 1.);
-  tuple->PostPreS_SegMinEtaSep_PassDz->Sumw2();
   tuple->PostPreS_Dz_FailSep = dir.make<TH1F>("PostPreS_Dz_FailSep", "PostPreS_Dz_FailSep", 50, -150, 150);
-  tuple->PostPreS_Dz_FailSep->Sumw2();
   
   tuple->PostPreS_Dxy_Cosmic = dir.make<TH1F>("PostPreS_Dxy_Cosmic", "PostPreS_Dxy_Cosmic", 150, -IPbound, IPbound);
-  tuple->PostPreS_Dxy_Cosmic->Sumw2();
   tuple->PostPreS_Dz_Cosmic = dir.make<TH1F>("PostPreS_Dz_Cosmic", "PostPreS_Dz_Cosmic", 150, -IPbound, IPbound);
-  tuple->PostPreS_Dz_Cosmic->Sumw2();
   tuple->PostPreS_Dz_CSC = dir.make<TH1F>("PostPreS_Dz_CSC", "PostPreS_Dz_CSC", 150, -IPbound, IPbound);
-  tuple->PostPreS_Dz_CSC->Sumw2();
   tuple->PostPreS_Dz_DT = dir.make<TH1F>("PostPreS_Dz_DT", "PostPreS_Dz_DT", 150, -IPbound, IPbound);
-  tuple->PostPreS_Dz_DT->Sumw2();
   tuple->PostPreS_Pt_FailDz = dir.make<TH1F>("PostPreS_Pt_FailDz", "PostPreS_Pt_FailDz", 50, 0, PtHistoUpperBound);
-  tuple->PostPreS_Pt_FailDz->Sumw2();
   tuple->PostPreS_Pt_FailDz_DT = dir.make<TH1F>("PostPreS_Pt_FailDz_DT", "PostPreS_Pt_FailDz_DT", 50, 0, PtHistoUpperBound);
-  tuple->PostPreS_Pt_FailDz_DT->Sumw2();
   tuple->PostPreS_Pt_FailDz_CSC = dir.make<TH1F>("PostPreS_Pt_FailDz_CSC", "PostPreS_Pt_FailDz_CSC", 50, 0, PtHistoUpperBound);
-  tuple->PostPreS_Pt_FailDz_CSC->Sumw2();
   tuple->PostPreS_TOF_FailDz = dir.make<TH1F>("PostPreS_TOF_FailDz", "PostPreS_TOF_FailDz", 150, -1, 5);
-  tuple->PostPreS_TOF_FailDz->Sumw2();
   tuple->PostPreS_TOF_FailDz_DT = dir.make<TH1F>("PostPreS_TOF_FailDz_DT", "PostPreS_TOF_FailDz_DT", 150, -1, 5);
-  tuple->PostPreS_TOF_FailDz_DT->Sumw2();
   tuple->PostPreS_TOF_FailDz_CSC = dir.make<TH1F>("PostPreS_TOF_FailDz_CSC", "PostPreS_TOF_FailDz_CSC", 150, -1, 5);
-  tuple->PostPreS_TOF_FailDz_CSC->Sumw2();
   tuple->PostPreS_PtErrOverPtVsPtErrOverPt2 = dir.make<TH2F>("PostPreS_PtErrOverPtVsPtErrOverPt2", "PostPreS_PtErrOverPtVsPtErrOverPt2",  40, 0., 1., 40, 0., 0.003);
-  tuple->PostPreS_PtErrOverPtVsPtErrOverPt2->Sumw2();
   tuple->PostPreS_PtErrOverPtVsPt = dir.make<TH2F>("PostPreS_PtErrOverPtVsPt", "PostPreS_PtErrOverPtVsPt",  40, 0., 1., 40, 0., 4000);
-  tuple->PostPreS_PtErrOverPtVsPt->Sumw2();
   tuple->PostPreS_GenPtVsRecoPt = dir.make<TH2F>("PostPreS_GenPtVsRecoPt", "PostPreS_GenPtVsRecoPt", 50, 0, PtHistoUpperBound, 50, 0, PtHistoUpperBound);
-  tuple->PostPreS_GenPtVsRecoPt->Sumw2();
   
   tuple->PostPreS_ProbQ = dir.make<TH1F>("PostPreS_ProbQ", ";ProbQ", 20, 0., 1.);
-  tuple->PostPreS_ProbQ->Sumw2();
   tuple->PostPreS_ProbQVsIas = dir.make<TH2F>("PostPreS_ProbQVsIas",";ProbQ;I_{as}", 20, 0., 1., 20, 0., 1.);
-  tuple->PostPreS_ProbQVsIas->Sumw2();
   tuple->PostPreS_ProbXY = dir.make<TH1F>("PostPreS_ProbXY", ";ProbXY", 100, 0, 1);
-  tuple->PostPreS_ProbXY->Sumw2();
   tuple->PostPreS_ProbXY_highIas = dir.make<TH1F>("PostPreS_ProbXY_highIas",";ProbXY (I_{as} > 0.6)", 100, 0, 1);
-  tuple->PostPreS_ProbXY_highIas->Sumw2();
   tuple->PostPreS_ProbXYVsIas = dir.make<TH2F>("PostPreS_ProbXYVsIas",";ProbXY;Ias",  100, 0, 1, 10, 0., 1.);
-  tuple->PostPreS_ProbXYVsIas->Sumw2();
   tuple->PostPreS_ProbXYVsIas_highIas = dir.make<TH2F>("PostPreS_ProbXYVsIas_highIas",";ProbXY (I_{as} > 0.6);Ias (I_{as} > 0.6)",  100, 0, 1, 10, 0., 1.);
-  tuple->PostPreS_ProbXYVsIas_highIas->Sumw2();
   tuple->PostPreS_ProbXYVsProbQ = dir.make<TH2F>("PostPreS_ProbXYVsProbQ",";ProbXY;ProbQ",  100, 0., 1., 10, 0., 1.);
-  tuple->PostPreS_ProbXYVsProbQ->Sumw2();
   tuple->PostPreS_ProbXYVsProbQ_highIas = dir.make<TH2F>("PostPreS_ProbXYVsProbQ_highIas",";ProbXY (I_{as} > 0.6);ProbQ (I_{as} > 0.6)",  100, 0., 1., 10, 0., 1.);
-  tuple->PostPreS_ProbXYVsProbQ_highIas->Sumw2();
   tuple->PostPreS_ProbQNoL1 = dir.make<TH1F>("PostPreS_ProbQNoL1",";ProbQNoL1", 20, 0., 1.);
-  tuple->PostPreS_ProbQNoL1->Sumw2();
   tuple->PostPreS_ProbQNoL1VsIas = dir.make<TH2F>("PostPreS_ProbQNoL1VsIas",";ProbQNoL1;I_{as}",20, 0., 1., 20, 0., 1.);
-  tuple->PostPreS_ProbQNoL1VsIas->Sumw2();
   tuple->PostPreS_ProbXYNoL1 = dir.make<TH1F>("PostPreS_ProbXYNoL1", ";ProbXYNoL1", 100, 0, 1);
-  tuple->PostPreS_ProbXYNoL1->Sumw2();
   tuple->PostPreS_ProbXYNoL1_highIas = dir.make<TH1F>("PostPreS_ProbXYNoL1_highIas", ";ProbXYNoL1 (I_{as} > 0.6)", 100, 0, 1);
-  tuple->PostPreS_ProbXYNoL1_highIas->Sumw2();
   tuple->PostPreS_ProbXYNoL1VsIas = dir.make<TH2F>("PostPreS_ProbXYNoL1VsIas",";ProbXYNoL1;Ias", 100, 0., 1., 20, 0.,1.);
-  tuple->PostPreS_ProbXYNoL1VsIas->Sumw2();
   tuple->PostPreS_ProbXYNoL1VsIas_highIas = dir.make<TH2F>("PostPreS_ProbXYNoL1VsIas_highIas",";ProbXYNoL1;I_{as} (I_{as} > 0.6)", 100, 0., 1., 20, 0.,1.);
-  tuple->PostPreS_ProbXYNoL1VsIas_highIas->Sumw2();
   tuple->PostPreS_ProbXYNoL1VsProbQNoL1  = dir.make<TH2F>("PostPreS_ProbXYNoL1VsProbQNoL1",";ProbXYNoL1;ProbQNoL1", 100, 0., 1., 20,0.,1.);
-  tuple->PostPreS_ProbXYNoL1VsProbQNoL1->Sumw2();
   tuple->PostPreS_ProbXYNoL1VsProbQNoL1_highIas  = dir.make<TH2F>("PostPreS_ProbXYNoL1VsProbQNoL1_highIas",";ProbXYNoL1 (I_{as} > 0.6);ProbQNoL1 (I_{as} > 0.6)", 100, 0., 1., 20,0.,1.);
-  tuple->PostPreS_ProbXYNoL1VsProbQNoL1_highIas->Sumw2();
 
   tuple->PostPreS_MassErr = dir.make<TH1F>("PostPreS_MassErr", ";MassErr/Mass", 50, 0., 10.);
-  tuple->PostPreS_MassErr->Sumw2();
   tuple->PostPreS_MassErrVsIas = dir.make<TH2F>("PostPreS_MassErrVsIas",";MassErr/Mass;I_{as}",50, 0., 10.,10,0.,1.);
-  tuple->PostPreS_MassErrVsIas->Sumw2();
 
   tuple->PostPreS_EtaVsGenID = dir.make<TH2F>("PostPreS_EtaVsGenID", "PostPreS_EtaVsGenID",  50, -2.6, 2.6, 4000, 0.0, 4000.0);
-  tuple->PostPreS_EtaVsGenID->Sumw2();
   tuple->PostPreS_ProbQVsGenID = dir.make<TH2F>("PostPreS_ProbQVsGenID", "PostPreS_ProbQVsGenID", 100, 0.0, 1.0, 4000, 0.0, 4000.0);
-  tuple->PostPreS_ProbQVsGenID->Sumw2();
 
   tuple->PostPreS_IasForStatus91 = dir.make<TH1F>("PostPreS_IasForStatus91",";I_{as} when status=91", 10, 0., 1.);
-  tuple->PostPreS_IasForStatus91->Sumw2();
   tuple->PostPreS_IasForStatusNot91 = dir.make<TH1F>("PostPreS_IasForStatusNot91",";I_{as} when status!=91", 10, 0., 1.);
-  tuple->PostPreS_IasForStatusNot91->Sumw2();
 
   tuple->PostPreS_ProbQVsGenEnviromentID = dir.make<TH2F>("PostPreS_ProbQVsGenEnviromentID",";ProbQ;GenEnviromentID",20, 0.0, 1.0, 4000, 0.0, 4000.0);
-  tuple->PostPreS_ProbQVsGenEnviromentID->Sumw2();
   tuple->PostPreS_ProbXYVsGenID = dir.make<TH2F>("PostPreS_ProbXYVsGenID", "PostPreS_ProbXYVsGenID", 100, 0.0, 1.0, 4000, 0.0, 4000.0);
-  tuple->PostPreS_ProbXYVsGenID->Sumw2();
   tuple->PostPreS_PtVsGenID = dir.make<TH2F>("PostPreS_PtVsGenID", "PostPreS_PtVsGenID", 50, 0, PtHistoUpperBound, 4000, 0.0, 4000.0);
-  tuple->PostPreS_PtVsGenID->Sumw2();
   tuple->PostPreS_EoPVsGenID = dir.make<TH2F>("PostPreS_EoPVsGenID", "PostPreS_EoPVsGenID", 25, 0, 1.5, 4000, 0.0, 4000.0);
-  tuple->PostPreS_EoPVsGenID->Sumw2();
   tuple->PostPreS_IhVsGenID = dir.make<TH2F>("PostPreS_IhVsGenID", "PostPreS_IhVsGenID", 200, 0, dEdxM_UpLim, 4000, 0.0, 4000.0);
-  tuple->PostPreS_IhVsGenID->Sumw2();
   tuple->PostPreS_IasVsGenID = dir.make<TH2F>("PostPreS_IasVsGenID", "PostPreS_IasVsGenID", 10, 0., 1., 4000, 0.0, 4000.0);
-  tuple->PostPreS_IasVsGenID->Sumw2();
   tuple->PostPreS_IasVsGenEnviromentID = dir.make<TH2F>("PostPreS_IasVsGenEnviromentID",";Ias;GenEnviromentID", 10, 0., 1., 4000, 0.0, 4000.0);
-  tuple->PostPreS_IasVsGenEnviromentID->Sumw2();
   tuple->PostPreS_massTVsGenID = dir.make<TH2F>("PostPreS_massTVsGenID", "PostPreS_massTVsGenID", 50, 0.0, 250.0, 4000, 0.0, 4000.0);
-  tuple->PostPreS_massTVsGenID->Sumw2();
   tuple->PostPreS_miniIsoChgVsGenID = dir.make<TH2F>("PostPreS_miniIsoChgVsGenID", "PostPreS_miniIsoChgVsGenID", 20, 0.0, 1.0, 4000, 0.0, 4000.0);
-  tuple->PostPreS_miniIsoChgVsGenID->Sumw2();
   tuple->PostPreS_miniIsoAllVsGenID = dir.make<TH2F>("PostPreS_miniIsoAllVsGenID", "PostPreS_miniIsoAllVsGenID", 20, 0.0, 1.0, 4000, 0.0, 4000.0);
-  tuple->PostPreS_miniIsoAllVsGenID->Sumw2();
   tuple->PostPreS_MassVsGenID = dir.make<TH2F>("PostPreS_MassVsGenID",";Mass (GeV);GenID",80,0.,4000.,4000, 0.0, 4000.0);
-  tuple->PostPreS_MassVsGenID->Sumw2();
 
   tuple->PostPreS_EtaVsMomGenID = dir.make<TH2F>("PostPreS_EtaVsMomGenID", "PostPreS_EtaVsMomGenID",  50, -2.6, 2.6, 4000, 0.0, 4000.0);
-  tuple->PostPreS_EtaVsMomGenID->Sumw2();
   tuple->PostPreS_ProbQVsMomGenID = dir.make<TH2F>("PostPreS_ProbQVsMomGenID", "PostPreS_ProbQVsMomGenID", 20, 0.0, 1.0, 4000, 0.0, 4000.0);
-  tuple->PostPreS_ProbQVsMomGenID->Sumw2();
   tuple->PostPreS_ProbXYVsMomGenID = dir.make<TH2F>("PostPreS_ProbXYVsMomGenID", "PostPreS_ProbXYVsMomGenID", 20, 0.0, 1.0, 4000, 0.0, 4000.0);
-  tuple->PostPreS_ProbXYVsMomGenID->Sumw2();
   tuple->PostPreS_PtVsMomGenID = dir.make<TH2F>("PostPreS_PtVsMomGenID", "PostPreS_PtVsMomGenID", 50, 0, PtHistoUpperBound, 4000, 0.0, 4000.0);
-  tuple->PostPreS_PtVsMomGenID->Sumw2();
   tuple->PostPreS_EoPVsMomGenID = dir.make<TH2F>("PostPreS_EoPVsMomGenID", "PostPreS_EoPVsMomGenID", 25, 0, 1.5, 4000, 0.0, 4000.0);
-  tuple->PostPreS_EoPVsMomGenID->Sumw2();
   tuple->PostPreS_IhVsMomGenID = dir.make<TH2F>("PostPreS_IhVsMomGenID", "PostPreS_IhVsMomGenID", 200, 0, dEdxM_UpLim, 4000, 0.0, 4000.0);
-  tuple->PostPreS_IhVsMomGenID->Sumw2();
   tuple->PostPreS_IasVsMomGenID = dir.make<TH2F>("PostPreS_IasVsMomGenID", "PostPreS_IasVsMomGenID", 10, 0., 1., 4000, 0.0, 4000.0);
-  tuple->PostPreS_IasVsMomGenID ->Sumw2();
   tuple->PostPreS_massTVsMomGenID = dir.make<TH2F>("PostPreS_massTVsMomGenID", "PostPreS_massTVsMomGenID", 50, 0.0, 250.0, 4000, 0.0, 4000.0);
-  tuple->PostPreS_massTVsMomGenID->Sumw2();
   tuple->PostPreS_miniIsoChgVsMomGenID = dir.make<TH2F>("PostPreS_miniIsoChgVsMomGenID", "PostPreS_miniIsoChgVsMomGenID", 20, 0.0, 1.0, 4000, 0.0, 4000.0);
-  tuple->PostPreS_miniIsoChgVsMomGenID->Sumw2();
   tuple->PostPreS_miniIsoAllVsMomGenID = dir.make<TH2F>("PostPreS_miniIsoAllVsMomGenID", "PostPreS_miniIsoAllVsMomGenID", 20, 0.0, 1.0, 4000, 0.0, 4000.0);
-  tuple->PostPreS_miniIsoAllVsMomGenID->Sumw2();
   tuple->PostPreS_MassVsMomGenID = dir.make<TH2F>("PostPreS_MassVsMomGenID","PostPreS_MassVsMomGenID;Mass;MomGenID",80,0.,4000.,4000, 0.0, 4000.0);
-  tuple->PostPreS_MassVsMomGenID->Sumw2();
   
   tuple->PostPreS_EtaVsSiblingGenID = dir.make<TH2F>("PostPreS_EtaVsSiblingGenID", "PostPreS_EtaVsSiblingGenID",  50, -2.6, 2.6, 4000, 0.0, 4000.0);
-  tuple->PostPreS_EtaVsSiblingGenID->Sumw2();
   tuple->PostPreS_ProbQVsSiblingGenID = dir.make<TH2F>("PostPreS_ProbQVsSiblingGenID", "PostPreS_ProbQVsSiblingGenID", 20, 0.0, 1.0, 4000, 0.0, 4000.0);
-  tuple->PostPreS_ProbQVsSiblingGenID->Sumw2();
   tuple->PostPreS_ProbXYVsSiblingGenID = dir.make<TH2F>("PostPreS_ProbXYVsSiblingGenID", "PostPreS_ProbXYVsSiblingGenID", 20, 0.0, 1.0, 4000, 0.0, 4000.0);
-  tuple->PostPreS_ProbXYVsSiblingGenID->Sumw2();
   tuple->PostPreS_PtVsSiblingGenID = dir.make<TH2F>("PostPreS_PtVsSiblingGenID", "PostPreS_PtVsSiblingGenID", 50, 0, PtHistoUpperBound, 4000, 0.0, 4000.0);
-  tuple->PostPreS_PtVsSiblingGenID->Sumw2();
   tuple->PostPreS_EoPVsSiblingGenID = dir.make<TH2F>("PostPreS_EoPVsSiblingGenID", "PostPreS_EoPVsSiblingGenID", 25, 0, 1.5, 4000, 0.0, 4000.0);
-  tuple->PostPreS_EoPVsSiblingGenID->Sumw2();
   tuple->PostPreS_IhVsSiblingGenID = dir.make<TH2F>("PostPreS_IhVsSiblingGenID", "PostPreS_IhVsSiblingGenID", 200, 0, dEdxM_UpLim, 4000, 0.0, 4000.0);
-  tuple->PostPreS_IhVsSiblingGenID->Sumw2();
   tuple->PostPreS_IasVsSiblingGenID = dir.make<TH2F>("PostPreS_IasVsSiblingGenID", "PostPreS_IasVsSiblingGenID", 10, 0., 1., 4000, 0.0, 4000.0);
-  tuple->PostPreS_IasVsSiblingGenID ->Sumw2();
   tuple->PostPreS_massTVsSiblingGenID = dir.make<TH2F>("PostPreS_massTVsSiblingGenID", ";massT;SiblingGenID", 50, 0.0, 250.0, 4000, 0.0, 4000.0);
-  tuple->PostPreS_massTVsSiblingGenID->Sumw2();
   tuple->PostPreS_MassVsSiblingGenID = dir.make<TH2F>("PostPreS_MassVsSiblingGenID", ";Mass;SiblingGenID",80, 0.0, 4000.0, 4000, 0.0, 4000.0);
-  tuple->PostPreS_MassVsSiblingGenID->Sumw2();
   
   tuple->PostPreS_EtaVsGenAngle = dir.make<TH2F>("PostPreS_EtaVsGenAngle", "PostPreS_EtaVsGenAngle",  50, -2.6, 2.6, 100, 0.0, 1.0);
-  tuple->PostPreS_EtaVsGenAngle->Sumw2();
   tuple->PostPreS_ProbQVsGenAngle = dir.make<TH2F>("PostPreS_ProbQVsGenAngle", "PostPreS_ProbQVsGenAngle", 20, 0.0, 1.0, 100, 0.0,1.0);
-  tuple->PostPreS_ProbQVsGenAngle->Sumw2();
   tuple->PostPreS_ProbXYVsGenAngle = dir.make<TH2F>("PostPreS_ProbXYVsGenAngle", "PostPreS_ProbXYVsGenAngle", 20, 0.0, 1.0, 100, 0.0, 1.0);
-  tuple->PostPreS_ProbXYVsGenAngle->Sumw2();
   tuple->PostPreS_PtVsGenAngle = dir.make<TH2F>("PostPreS_PtVsGenAngle", "PostPreS_PtVsGenAngle", 50, 0, PtHistoUpperBound, 100, 0.0, 1.0);
-  tuple->PostPreS_PtVsGenAngle->Sumw2();
   tuple->PostPreS_EoPVsGenAngle = dir.make<TH2F>("PostPreS_EoPVsGenAngle", "PostPreS_EoPVsGenAngle", 25, 0, 1.5, 100, 0.0, 1.0);
-  tuple->PostPreS_EoPVsGenAngle->Sumw2();
   tuple->PostPreS_IhVsGenAngle = dir.make<TH2F>("PostPreS_IhVsGenAngle", "PostPreS_IhVsGenAngle", 200, 0, dEdxM_UpLim, 100, 0.0, 1.0);
-  tuple->PostPreS_IhVsGenAngle->Sumw2();
   tuple->PostPreS_IasVsGenAngle = dir.make<TH2F>("PostPreS_IasVsGenAngle", "PostPreS_IasVsGenAngle", 10, 0., 1., 100, 0.0, 1.0);
-  tuple->PostPreS_IasVsGenAngle ->Sumw2();
   tuple->PostPreS_massTVsGenAngle = dir.make<TH2F>("PostPreS_massTVsGenAngle", "PostPreS_massTVsGenAngle", 50, 0.0, 250.0, 100, 0.0, 1.0);
-  tuple->PostPreS_massTVsGenAngle->Sumw2();
   tuple->PostPreS_miniIsoChgVsGenAngle = dir.make<TH2F>("PostPreS_miniIsoChgVsGenAngle", "PostPreS_miniIsoChgVsGenAngle", 20, 0.0, 1.0, 100, 0.0, 1.0);
-  tuple->PostPreS_miniIsoChgVsGenAngle->Sumw2();
   tuple->PostPreS_miniIsoAllVsGenAngle = dir.make<TH2F>("PostPreS_miniIsoAllVsGenAngle", "PostPreS_miniIsoAllVsGenAngle", 20, 0.0, 1.0, 100, 0.0, 1.0);
-  tuple->PostPreS_miniIsoAllVsGenAngle->Sumw2();
   tuple->PostPreS_MassVsGenAngle = dir.make<TH2F>("PostPreS_MassVsGenAngle",";Mass;GenAngle",80, 0.0,4000.0,  100, 0.0, 1.0);
-  tuple->PostPreS_MassVsGenAngle->Sumw2();
   
   tuple->PostPreS_EtaVsGenMomAngle = dir.make<TH2F>("PostPreS_EtaVsGenMomAngle", "PostPreS_EtaVsGenMomAngle",  50, -2.6, 2.6, 100, 0.0, 1.0);
-  tuple->PostPreS_EtaVsGenMomAngle->Sumw2();
   tuple->PostPreS_ProbQVsGenMomAngle = dir.make<TH2F>("PostPreS_ProbQVsGenMomAngle", "PostPreS_ProbQVsGenMomAngle", 20, 0.0, 1.0, 100, 0.0,1.0);
-  tuple->PostPreS_ProbQVsGenMomAngle->Sumw2();
   tuple->PostPreS_ProbXYVsGenMomAngle = dir.make<TH2F>("PostPreS_ProbXYVsGenMomAngle", "PostPreS_ProbXYVsGenMomAngle", 20, 0.0, 1.0, 100, 0.0, 1.0);
-  tuple->PostPreS_ProbXYVsGenMomAngle->Sumw2();
   tuple->PostPreS_PtVsGenMomAngle = dir.make<TH2F>("PostPreS_PtVsGenMomAngle", "PostPreS_PtVsGenMomAngle", 50, 0, PtHistoUpperBound, 100, 0.0, 1.0);
-  tuple->PostPreS_PtVsGenMomAngle->Sumw2();
   tuple->PostPreS_EoPVsGenMomAngle = dir.make<TH2F>("PostPreS_EoPVsGenMomAngle", "PostPreS_EoPVsGenMomAngle", 25, 0, 1.5, 100, 0.0, 1.0);
-  tuple->PostPreS_EoPVsGenMomAngle->Sumw2();
   tuple->PostPreS_IhVsGenMomAngle = dir.make<TH2F>("PostPreS_IhVsGenMomAngle", "PostPreS_IhVsGenMomAngle", 100, 0, dEdxM_UpLim, 100, 0.0, 1.0);
-  tuple->PostPreS_IhVsGenMomAngle->Sumw2();
   tuple->PostPreS_IasVsGenMomAngle = dir.make<TH2F>("PostPreS_IasVsGenMomAngle", "PostPreS_IasVsGenMomAngle", 10, 0., 1., 100, 0.0, 1.0);
-  tuple->PostPreS_IasVsGenMomAngle ->Sumw2();
   tuple->PostPreS_massTVsGenMomAngle = dir.make<TH2F>("PostPreS_massTVsGenMomAngle", "PostPreS_massTVsGenMomAngle", 50, 0.0, 250.0, 100, 0.0, 1.0);
-  tuple->PostPreS_massTVsGenMomAngle->Sumw2();
   tuple->PostPreS_miniIsoChgVsGenMomAngle = dir.make<TH2F>("PostPreS_miniIsoChgVsGenMomAngle", "PostPreS_miniIsoChgVsGenMomAngle", 20, 0.0, 1.0, 100, 0.0, 1.0);
-  tuple->PostPreS_miniIsoChgVsGenMomAngle->Sumw2();
   tuple->PostPreS_miniIsoAllVsGenMomAngle = dir.make<TH2F>("PostPreS_miniIsoAllVsGenMomAngle", "PostPreS_miniIsoAllVsGenMomAngle", 20, 0.0, 1.0, 100, 0.0, 1.0);
-  tuple->PostPreS_miniIsoAllVsGenMomAngle->Sumw2();
   tuple->PostPreS_MassVsGenMomAngle = dir.make<TH2F>("PostPreS_MassVsGenMomAngle",";Mass;GenMomAngle",80,0.,4000., 100, 0.0, 1.0);
-  tuple->PostPreS_MassVsGenMomAngle->Sumw2();
 
   tuple->PostPreS_ProbQVsIas = dir.make<TH2F>("PostPreS_ProbQVsIas", "PostPreS_ProbQVsIas", 20, 0., 1., 20, 0., 1.);
-  tuple->PostPreS_ProbQVsIas->Sumw2();
 
   tuple->PostPreS_EtaVsGenNumSibling = dir.make<TH2F>("PostPreS_EtaVsGenNumSibling", "PostPreS_EtaVsGenNumSibling",  50, -2.6, 2.6, 100, 0.0, 10.0);
-  tuple->PostPreS_EtaVsGenNumSibling->Sumw2();
   tuple->PostPreS_ProbQVsGenNumSibling = dir.make<TH2F>("PostPreS_ProbQVsGenNumSibling", "PostPreS_ProbQVsGenNumSibling", 20, 0., 1., 10, 0.0,10.);
-  tuple->PostPreS_ProbQVsGenNumSibling->Sumw2();
   tuple->PostPreS_ProbXYVsGenNumSibling = dir.make<TH2F>("PostPreS_ProbXYVsGenNumSibling", "PostPreS_ProbXYVsGenNumSibling", 20, 0.0, 1.0, 10, 0.0, 10.0);
-  tuple->PostPreS_ProbXYVsGenNumSibling->Sumw2();
   tuple->PostPreS_PtVsGenNumSibling = dir.make<TH2F>("PostPreS_PtVsGenNumSibling", "PostPreS_PtVsGenNumSibling", 50, 0, PtHistoUpperBound, 100, 0.0, 10.0);
-  tuple->PostPreS_PtVsGenNumSibling->Sumw2();
   tuple->PostPreS_EoPVsGenNumSibling = dir.make<TH2F>("PostPreS_EoPVsGenNumSibling", "PostPreS_EoPVsGenNumSibling", 25, 0, 1.5, 100, 0.0, 10.0);
-  tuple->PostPreS_EoPVsGenNumSibling->Sumw2();
   tuple->PostPreS_IhVsGenNumSibling = dir.make<TH2F>("PostPreS_IhVsGenNumSibling", "PostPreS_IhVsGenNumSibling", 200, 0, dEdxM_UpLim, 100, 0.0, 10.0);
-  tuple->PostPreS_IhVsGenNumSibling->Sumw2();
   tuple->PostPreS_IasVsGenNumSibling = dir.make<TH2F>("PostPreS_IasVsGenNumSibling", "PostPreS_IasVsGenNumSibling", 10, 0., 1., 100, 0.0, 10.0);
-  tuple->PostPreS_IasVsGenNumSibling ->Sumw2();
   tuple->PostPreS_massTVsGenNumSibling = dir.make<TH2F>("PostPreS_massTVsGenNumSibling", "PostPreS_massTVsGenNumSibling", 50, 0.0, 250.0, 100, 0.0, 10.0);
-  tuple->PostPreS_massTVsGenNumSibling->Sumw2();
   tuple->PostPreS_miniIsoChgVsGenNumSibling = dir.make<TH2F>("PostPreS_miniIsoChgVsGenNumSibling", "PostPreS_miniIsoChgVsGenNumSibling", 20, 0.0, 1.0, 100, 0.0, 10.0);
-  tuple->PostPreS_miniIsoChgVsGenNumSibling->Sumw2();
   tuple->PostPreS_miniIsoAllVsGenNumSibling = dir.make<TH2F>("PostPreS_miniIsoAllVsGenNumSibling", "PostPreS_miniIsoAllVsGenNumSibling", 20, 0.0, 1.0, 100, 0.0, 10.0);
-  tuple->PostPreS_miniIsoAllVsGenNumSibling->Sumw2();
 
   tuple->PostPreS_EoPVsPfType = dir.make<TH2F>("PostPreS_EoPVsPfType", "PostPreS_EoPVsPfType", 25, 0.0, 1.5, 9, 0.0, 9.0);
-  tuple->PostPreS_EoPVsPfType->Sumw2();
   tuple->PostPreS_Mass = dir.make<TH1F>("PostPreS_Mass","PostPreS_Mass;Mass (GeV);Tracks / 50 GeV", 80,0.,4000.);
-  tuple->PostPreS_Mass->Sumw2();
   tuple->PostPreS_MassVsPfType = dir.make<TH2F>("PostPreS_MassVsPfType","PostPreS_MassVsPfType;Mass (GeV);PF ID",80,0.,4000.,9, 0.0, 9.0);
-  tuple->PostPreS_MassVsPfType->Sumw2();
   tuple->PostPreS_MassVsPt = dir.make<TH2F>("PostPreS_MassVsPt", ";Mass (GeV);", 80,0.,4000.,80,0.,4000.);
-  tuple->PostPreS_MassVsPt->Sumw2();
   tuple->PostPreS_MassVsP = dir.make<TH2F>("PostPreS_MassVsP", ";Mass (GeV);", 80,0.,4000.,80,0.,4000.);
-  tuple->PostPreS_MassVsP->Sumw2();
   tuple->PostPreS_MassVsTNOHFraction = dir.make<TH2F>("PostPreS_MassVsTNOHFraction", ";Mass (GeV);", 80,0.,4000.,50, 0, 1);
-  tuple->PostPreS_MassVsTNOHFraction->Sumw2();
   tuple->PostPreS_MassVsTNOPH = dir.make<TH2F>("PostPreS_MassVsTNOPH", ";Mass (GeV);", 80,0.,4000.,8, -0.5, 7.5);
-  tuple->PostPreS_MassVsTNOPH->Sumw2();
   tuple->PostPreS_MassVsTNOM = dir.make<TH2F>("PostPreS_MassVsTNOM", ";Mass (GeV);", 80,0.,4000.,40, -0.5, 39.5);
-  tuple->PostPreS_MassVsTNOM->Sumw2();
   tuple->PostPreS_MassVsProbQNoL1 = dir.make<TH2F>("PostPreS_MassVsProbQNoL1", ";Mass (GeV);", 80,0.,4000.,20,0.,1.);
-  tuple->PostPreS_MassVsProbQNoL1->Sumw2();
   tuple->PostPreS_MassVsProbXYNoL1 = dir.make<TH2F>("PostPreS_MassVsProbXYNoL1", ";Mass (GeV);", 80,0.,4000.,20,0.,1.);
-  tuple->PostPreS_MassVsProbXYNoL1->Sumw2();
   tuple->PostPreS_MassVsEoP = dir.make<TH2F>("PostPreS_MassVsEoP", ";Mass (GeV);", 80,0.,4000.,30, 0, 0.3);
-  tuple->PostPreS_MassVsEoP->Sumw2();
   tuple->PostPreS_MassVsSumpTOverpT = dir.make<TH2F>("PostPreS_MassVsSumpTOverpT", ";Mass (GeV);", 80,0.,4000.,80, 0, 2);
-  tuple->PostPreS_MassVsSumpTOverpT->Sumw2();
   tuple->PostPreS_MassVsPtErrOverPt = dir.make<TH2F>("PostPreS_MassVsPtErrOverPt", ";Mass (GeV);", 80,0.,4000.,40, 0, 1);
-  tuple->PostPreS_MassVsPtErrOverPt->Sumw2();
   tuple->PostPreS_MassVsTIsol = dir.make<TH2F>("PostPreS_MassVsTIsol", ";Mass (GeV);", 80,0.,4000., 25, 0, 100);
-  tuple->PostPreS_MassVsTIsol->Sumw2();
   tuple->PostPreS_MassVsIh = dir.make<TH2F>("PostPreS_MassVsIh", ";Mass (GeV);", 80,0.,4000.,200, 0, dEdxM_UpLim);
-  tuple->PostPreS_MassVsIh->Sumw2();
   tuple->PostPreS_MassVsMassT = dir.make<TH2F>("PostPreS_MassVsMassT", ";Mass (GeV);", 80,0.,4000.,50, 0.0, 250.0);
-  tuple->PostPreS_MassVsMassT->Sumw2();
   tuple->PostPreS_MassVsMiniRelIsoAll = dir.make<TH2F>("PostPreS_MassVsMiniRelIsoAll", ";Mass (GeV);", 80,0.,4000.,20, 0., 0.2);
-  tuple->PostPreS_MassVsMiniRelIsoAll->Sumw2();
   tuple->PostPreS_MassVsMassErr = dir.make<TH2F>("PostPreS_MassVsMassErr", ";Mass (GeV);", 80,0.,4000.,50, 0., 10.);
-  tuple->PostPreS_MassVsMassErr->Sumw2();
   
   // Maybe we dont need these anymore
   tuple->PostPreS_IasAllIhVsLayer = dir.make<TH3F>("PostPreS_IasAllIhVsLayer", "PostPreS_IasAllIhVsLayer", 50, 0., dEdxS_UpLim, 200, 0., dEdxM_UpLim, 35, 0.,35.);
-  tuple->PostPreS_IasAllIhVsLayer->Sumw2();
   tuple->PostPreS_IasPixelIhVsLayer = dir.make<TH3F>("PostPreS_IasPixelIhVsLayer", "PostPreS_IasPixelIhVsLayer", 50, 0., dEdxS_UpLim, 200, 0., dEdxM_UpLim, 10, 0.,10.);
-  tuple->PostPreS_IasPixelIhVsLayer->Sumw2();
   tuple->PostPreS_IasStripIhVsLayer = dir.make<TH3F>("PostPreS_IasStripIhVsLayer", "PostPreS_IasStripIhVsLayer", 50, 0., dEdxS_UpLim, 200, 0., dEdxM_UpLim, 25, 0.,25.);
-  tuple->PostPreS_IasStripIhVsLayer->Sumw2();
 
   tuple->PostPreS_CluProbQVsPixelLayer = dir.make<TH2F>("PostPreS_CluProbQVsPixelLayer",";CluProbQ;Layer",20,0.,1.,4,0.,4.);
-  tuple->PostPreS_CluProbQVsPixelLayer->Sumw2();
   tuple->PostPreS_CluProbXYVsPixelLayer = dir.make<TH2F>("PostPreS_CluProbXYVsPixelLayer",";CluProbXY;Layer",100,0.,1.,4,0.,4.);
-  tuple->PostPreS_CluProbXYVsPixelLayer->Sumw2();
   tuple->PostPreS_CluSizeVsPixelLayer = dir.make<TH2F>("PostPreS_CluSizeVsPixelLayer",";CluSize;Layer",10,0.,10.,4,0.,4.);
-  tuple->PostPreS_CluSizeVsPixelLayer->Sumw2();
   tuple->PostPreS_CluSizeXVsPixelLayer = dir.make<TH2F>("PostPreS_CluSizeXVsPixelLayer",";CluSizeX;Layer",10,0.,10.,4,0.,4.);
-  tuple->PostPreS_CluSizeXVsPixelLayer->Sumw2();
   tuple->PostPreS_CluSizeYVsPixelLayer = dir.make<TH2F>("PostPreS_CluSizeYVsPixelLayer",";CluSizeY;Layer",10,0.,10.,4,0.,4.);
-  tuple->PostPreS_CluSizeYVsPixelLayer->Sumw2();
   tuple->PostPreS_CluSpecInCPEVsPixelLayer = dir.make<TH2F>("PostPreS_CluSpecInCPEVsPixelLayer",";CluSpecInCPE;Layer",4,0.,4.,4,0.,4.);
-  tuple->PostPreS_CluSpecInCPEVsPixelLayer->Sumw2();
 
   tuple->PostPreS_CluProbQVsPixelLayer_highIas = dir.make<TH2F>("PostPreS_CluProbQVsPixelLayer_highIas",";CluProbQ;Layer",20,0.,1.,4,0.,4.);
-  tuple->PostPreS_CluProbQVsPixelLayer_highIas->Sumw2();
   tuple->PostPreS_CluProbXYVsPixelLayer_highIas = dir.make<TH2F>("PostPreS_CluProbXYVsPixelLayer_highIas",";CluProbXY;Layer",100,0.,1.,4,0.,4.);
-  tuple->PostPreS_CluProbXYVsPixelLayer_highIas->Sumw2();
   tuple->PostPreS_CluSizeVsPixelLayer_highIas = dir.make<TH2F>("PostPreS_CluSizeVsPixelLayer_highIas",";CluSize;Layer",10,0.,10.,4,0.,4.);
-  tuple->PostPreS_CluSizeVsPixelLayer_highIas->Sumw2();
   tuple->PostPreS_CluSizeXVsPixelLayer_highIas = dir.make<TH2F>("PostPreS_CluSizeXVsPixelLayer_highIas",";CluSizeX;Layer",10,0.,10.,4,0.,4.);
-  tuple->PostPreS_CluSizeXVsPixelLayer_highIas->Sumw2();
   tuple->PostPreS_CluSizeYVsPixelLayer_highIas = dir.make<TH2F>("PostPreS_CluSizeYVsPixelLayer_highIas",";CluSizeY;Layer",10,0.,10.,4,0.,4.);
-  tuple->PostPreS_CluSizeYVsPixelLayer_highIas->Sumw2();
   tuple->PostPreS_CluSpecInCPEVsPixelLayer_highIas = dir.make<TH2F>("PostPreS_CluSpecInCPEVsPixelLayer_highIas",";CluSpecInCPE;Layer",4,0.,4.,4,0.,4.);
-  tuple->PostPreS_CluSpecInCPEVsPixelLayer_highIas->Sumw2();
 
   tuple->PostPreS_CluCotBetaVsPixelLayer_lowProbXY = dir.make<TH2F>("PostPreS_CluCotBetaVsPixelLayer_lowProbXY",";CotBeta;Layer",200,-10.,10.,4,0.,4.);
-  tuple->PostPreS_CluCotBetaVsPixelLayer_lowProbXY->Sumw2();
   tuple->PostPreS_CluCotAlphaVsPixelLayer_lowProbXY = dir.make<TH2F>("PostPreS_CluCotAlphaVsPixelLayer_lowProbXY",";CotAlpha;Layer",100,-1.,1.,4,0.,4.);
-  tuple->PostPreS_CluCotAlphaVsPixelLayer_lowProbXY->Sumw2();
   tuple->PostPreS_CluCotBetaVsPixelLayer = dir.make<TH2F>("PostPreS_CluCotBetaVsPixelLayer",";CotBeta;Layer",200,-10.,10.,4,0.,4.);
-  tuple->PostPreS_CluCotBetaVsPixelLayer->Sumw2();
   tuple->PostPreS_CluCotAlphaVsPixelLayer = dir.make<TH2F>("PostPreS_CluCotAlphaVsPixelLayer",";CotAlpha;Layer",100,-1.,1.,4,0.,4.);
-  tuple->PostPreS_CluCotAlphaVsPixelLayer->Sumw2();
 
   tuple->PostPreS_CluNormChargeVsStripLayer_lowBetaGamma = dir.make<TH2F>("PostPreS_CluNormChargeVsStripLayer_lowBetaGamma",";CluNormCharge;Layer",600,0.,600.,20,0.,20.);
-  tuple->PostPreS_CluNormChargeVsStripLayer_lowBetaGamma->Sumw2();
   tuple->PostPreS_CluNormChargeVsStripLayer_higherBetaGamma = dir.make<TH2F>("PostPreS_CluNormChargeVsStripLayer_higherBetaGamma",";CluNormCharge;Layer",600,0.,600.,20,0.,20.);
-  tuple->PostPreS_CluNormChargeVsStripLayer_higherBetaGamma->Sumw2();
   tuple->PostPreS_CluNormChargeVsStripLayer_higherBetaGamma_Stat91 = dir.make<TH2F>("PostPreS_CluNormChargeVsStripLayer_higherBetaGamma_Stat91",";CluNormCharge;Layer",600,0.,600.,20,0.,20.);
-  tuple->PostPreS_CluNormChargeVsStripLayer_higherBetaGamma_Stat91->Sumw2();
   tuple->PostPreS_CluNormChargeVsStripLayer_higherBetaGamma_StatNot91 = dir.make<TH2F>("PostPreS_CluNormChargeVsStripLayer_higherBetaGamma_StatNot91",";CluNormCharge;Layer",600,0.,600.,20,0.,20.);
-  tuple->PostPreS_CluNormChargeVsStripLayer_higherBetaGamma_StatNot91->Sumw2();
   tuple->PostPreS_CluNormChargeVsStripLayer_higherBetaGamma_StatHigherThan2 = dir.make<TH2F>("PostPreS_CluNormChargeVsStripLayer_higherBetaGamma_StatHigherThan2",";CluNormCharge;Layer",600,0.,600.,20,0.,20.);
-  tuple->PostPreS_CluNormChargeVsStripLayer_higherBetaGamma_StatHigherThan2->Sumw2();
 
   tuple->PostPreS_dRMinPfJet = dir.make<TH1F>("PostPreS_dRMinPfJet",";dRMinPfJet",100,0.,1.5);
-  tuple->PostPreS_dRMinPfJet->Sumw2();
   tuple->PostPreS_closestPfJetMuonFraction = dir.make<TH1F>("PostPreS_closestPfJetMuonFraction",":closestPfJetMuonFraction",20,0.,1.);
-  tuple->PostPreS_closestPfJetMuonFraction->Sumw2();
   tuple->PostPreS_closestPfJetElectronFraction = dir.make<TH1F>("PostPreS_closestPfJetElectronFraction",";closestPfJetElectronFraction",20,0.,1.);
-  tuple->PostPreS_closestPfJetElectronFraction->Sumw2();
   tuple->PostPreS_closestPfJetPhotonFraction = dir.make<TH1F>("PostPreS_closestPfJetPhotonFraction",";closestPfJetPhotonFraction",20,0.,1.);
-  tuple->PostPreS_closestPfJetPhotonFraction->Sumw2();
 
   tuple->PostPreS_closestPfJetMuonFractionVsIas = dir.make<TH2F>("PostPreS_closestPfJetMuonFractionVsIas",":closestPfJetMuonFraction;Ias",20,0.,1.,20,0.,1.);
-  tuple->PostPreS_closestPfJetMuonFractionVsIas->Sumw2();
   tuple->PostPreS_closestPfJetElectronFractionVsIas = dir.make<TH2F>("PostPreS_closestPfJetElectronFractionVsIas",";closestPfJetElectronFraction;Ias",20,0.,1.,20,0.,1.);
-  tuple->PostPreS_closestPfJetElectronFractionVsIas->Sumw2();
   tuple->PostPreS_closestPfJetPhotonFractionVsIas = dir.make<TH2F>("PostPreS_closestPfJetPhotonFractionVsIas",";closestPfJetPhotonFraction;Ias",20,0.,1.,20,0.,1.);
-  tuple->PostPreS_closestPfJetPhotonFractionVsIas->Sumw2();
 
   tuple->PostPreS_dRMinPfJetVsIas = dir.make<TH2F>("PostPreS_dRMinPfJetVsIas", ";dRMinPfJet;Ias",100,0.,1.5,10,0.,1.);
-  tuple->PostPreS_dRMinPfJetVsIas->Sumw2();
   tuple->PostPreS_dRMinCaloJet = dir.make<TH1F>("PostPreS_dRMinCaloJet",";dRMinCaloJet",100,0.,1.5);
-  tuple->PostPreS_dRMinCaloJet->Sumw2();
   tuple->PostPreS_dPhiMinPfMet = dir.make<TH1F>("PostPreS_dPhiMinPfMet",";dPhiMinPfMet",100,0.,3.2);
-  tuple->PostPreS_dPhiMinPfMet->Sumw2();
 
   tuple->PostPreS_dRMinCaloJetVsIas =  dir.make<TH2F>("PostPreS_dRMinCaloJetVsIas",";dRMinCaloJet;Ias",100,0.,1.5,10,0.,1.);
-  tuple->PostPreS_dRMinCaloJetVsIas->Sumw2();
   tuple->PostPreS_dPhiMinPfMetVsIas =  dir.make<TH2F>("PostPreS_dPhiMinPfMetVsIas",";dPhiMinPfMet;Ias",100,0.,3.2,10,0.,1.);
-  tuple->PostPreS_dPhiMinPfMetVsIas->Sumw2();
 
   tuple->PostPreS_PfMet = dir.make<TH1F>("PostPreS_PfMet",";PfMet",200,0.,2000.);
-  tuple->PostPreS_PfMet->Sumw2();
   tuple->PostPreS_PfMetPhi = dir.make<TH1F>("PostPreS_PfMetPhi",";PfMetPhi",30,0.,3.2);
-  tuple->PostPreS_PfMetPhi->Sumw2();
   
   tuple->GenLevelBinning = dir.make<TH1F>("GenLevelBinning","GenLevelBinning",1200,0.,1200.);
-  tuple->GenLevelBinning->Sumw2();
   tuple->GenLevelpT = dir.make<TH1F>("GenLevelpT", "GenLevelpT;Generator p_{T} (GeV)", 50, 0, PtHistoUpperBound);
-  tuple->GenLevelpT->Sumw2();
   tuple->GenLevelEta = dir.make<TH1F>("GenLevelEta",";Generator #eta", 60, -3, 3);
-  tuple->GenLevelEta->Sumw2();
   tuple->GenLevelBeta = dir.make<TH1F>("GenLevelBeta",";Generator #beta", 20, 0, 1);
-  tuple->GenLevelBeta->Sumw2();
   tuple->GenLevelBetaGamma = dir.make<TH1F>("GenLevelBetaGamma",";Generator #beta #gamma;Gen canidate",4500,0.,450.);
-  tuple->GenLevelBetaGamma->Sumw2();
 
   //Initialize histograms for number of bins.  For everything but muon only PredBins=0 so no histograms created
   for (int i = 0; i < PredBins; i++) {
@@ -1254,46 +827,28 @@ void TupleMaker::initializeTuple(Tuple *&tuple,
     sprintf(Suffix, "_%i", i);
       Name.append(Suffix);
     tuple->BefPreS_Pt_Binned[std::to_string(i)] = dir.make<TH1F>("BefPreS_Pt_Binned", "BefPreS_Pt_Binned", 50, 0, PtHistoUpperBound);
-    tuple->BefPreS_Pt_Binned[std::to_string(i)]->Sumw2();
       Name.append(Suffix);
     tuple->BefPreS_TOF_Binned[std::to_string(i)] = dir.make<TH1F>("BefPreS_TOF_Binned", "BefPreS_TOF_Binned", 150, -1, 5);
-    tuple->BefPreS_TOF_Binned[std::to_string(i)]->Sumw2();
   }
 
   tuple->PostS_CutIdVsEta_RegionA = dir.make<TH2F>("PostS_CutIdVsEta_RegionA", ";NCuts;#eta (RegionA)", NCuts, 0, NCuts, 52, -2.6, 2.6);
-  tuple->PostS_CutIdVsEta_RegionA->Sumw2();
   tuple->PostS_CutIdVsEta_RegionB = dir.make<TH2F>("PostS_CutIdVsEta_RegionB", ";NCuts;#eta (RegionB)", NCuts, 0, NCuts, 52, -2.6, 2.6);
-  tuple->PostS_CutIdVsEta_RegionB->Sumw2();
   tuple->PostS_CutIdVsEta_RegionC = dir.make<TH2F>("PostS_CutIdVsEta_RegionC", ";NCuts;#eta (RegionC)", NCuts, 0, NCuts, 52, -2.6, 2.6);
-  tuple->PostS_CutIdVsEta_RegionC->Sumw2();
   tuple->PostS_CutIdVsEta_RegionD = dir.make<TH2F>("PostS_CutIdVsEta_RegionD", ";NCuts;#eta (RegionD)", NCuts, 0, NCuts, 52, -2.6, 2.6);
-  tuple->PostS_CutIdVsEta_RegionD->Sumw2();
   tuple->PostS_CutIdVsEta_RegionE = dir.make<TH2F>("PostS_CutIdVsEta_RegionE", ";NCuts;#eta (RegionE)", NCuts, 0, NCuts, 52, -2.6, 2.6);
-  tuple->PostS_CutIdVsEta_RegionE->Sumw2();
   tuple->PostS_CutIdVsEta_RegionF = dir.make<TH2F>("PostS_CutIdVsEta_RegionF", ";NCuts;#eta (RegionF)", NCuts, 0, NCuts, 52, -2.6, 2.6);
-  tuple->PostS_CutIdVsEta_RegionF->Sumw2();
   tuple->PostS_CutIdVsEta_RegionG = dir.make<TH2F>("PostS_CutIdVsEta_RegionG", ";NCuts;#eta (RegionG)", NCuts, 0, NCuts, 52, -2.6, 2.6);
-  tuple->PostS_CutIdVsEta_RegionG->Sumw2();
   tuple->PostS_CutIdVsEta_RegionH = dir.make<TH2F>("PostS_CutIdVsEta_RegionH", ";NCuts;#eta (RegionH)", NCuts, 0, NCuts, 52, -2.6, 2.6);
-  tuple->PostS_CutIdVsEta_RegionH->Sumw2();
   
   tuple->PostS_CutIdVsBeta_postPt = dir.make<TH2F>("PostS_CutIdVsBeta_postPt", ";NCuts;#beta (p_{T} > p_{T,cut})", NCuts, 0, NCuts, 20, 0, 1);
-  tuple->PostS_CutIdVsBeta_postPt->Sumw2();
   tuple->PostS_CutIdVsBeta_postPtAndIas = dir.make<TH2F>("PostS_CutIdVsBeta_postPtAndIas", ";NCuts;#beta (p_{T} > p_{T,cut} and I_{as} > I_{as,cut} )", NCuts, 0, NCuts, 20, 0, 1);
-  tuple->PostS_CutIdVsBeta_postPtAndIas->Sumw2();
   tuple->PostS_CutIdVsBeta_postPtAndIasAndTOF = dir.make<TH2F>("PostS_CutIdVsBeta_postPtAndIasAndTOF", ";NCuts;#beta (p_{T} > p_{T,cut} and I_{as} > I_{as,cut} and TOF > TOF_{cut} ", NCuts, 0, NCuts, 20, 0, 1);
-  tuple->PostS_CutIdVsBeta_postPtAndIasAndTOF->Sumw2();
 
   tuple->PostS_CutIdVsP = dir.make<TH2F>("PostS_CutIdVsP", ";NCuts;PostS_P", NCuts, 0, NCuts, 50, 0, PtHistoUpperBound);
-  tuple->PostS_CutIdVsP->Sumw2();
   tuple->PostS_CutIdVsPt = dir.make<TH2F>("PostS_CutIdVsPt", ";NCuts;PostS_Pt", NCuts, 0, NCuts, 50, 0, PtHistoUpperBound);
-  tuple->PostS_CutIdVsPt->Sumw2();
   tuple->PostS_CutIdVsIas = dir.make<TH2F>("PostS_CutIdVsIas", ";NCuts;PostS_Ias", NCuts, 0, NCuts, 10, 0., 1.);
-  tuple->PostS_CutIdVsIas->Sumw2();
   tuple->PostS_CutIdVsIh = dir.make<TH2F>("PostS_CutIdVsIh", ";NCuts;PostS_Ih", NCuts, 0, NCuts, 100, 0, dEdxM_UpLim);
-  tuple->PostS_CutIdVsIh->Sumw2();
   tuple->PostS_CutIdVsTOF = dir.make<TH2F>("PostS_CutIdVsTOF", ";NCuts;PostS_TOF", NCuts, 0, NCuts, 50, 1, 5);
-  tuple->PostS_CutIdVsTOF->Sumw2();
 //tuple->PostS_CutIdVsEtaVsIas = dir.make<TH3F>("PostS_CutIdVsEtaVsIas", ";NCuts;PostS_EtaIs", NCuts, 0,  NCuts, 50,-3, 3, 10, 0., 1.);
 //tuple->PostS_CutIdVsEtaVsIm = dir.make<TH3F>("PostS_CutIdVsEtaVsIm", ";NCuts;PostS_EtaIh", NCuts, 0,  NCuts, 50,-3, 3,100, 0, dEdxM_UpLim);
 //tuple->PostS_CutIdVsEtaVsP  = dir.make<TH3F>("PostS_CutIdVsEtaVsP", ";NCuts;PostS_EtaP", NCuts, 0,  NCuts, 50,-3, 3, 50, 0, PtHistoUpperBound);
@@ -1307,28 +862,19 @@ void TupleMaker::initializeTuple(Tuple *&tuple,
   tuple->PostS_CutIdVsTOFVsIh = dir.make<TH3F>("PostS_CutIdVsTOFVsIh", ";NCuts;TOF;Ih", NCuts, 0, NCuts, 50, 0, 5, 100, 0, dEdxM_UpLim);
 
   tuple->H_D_DzSidebands = dir.make<TH2F>("H_D_DzSidebands", ";NCuts;H_D_DzSidebands", NCuts, 0, NCuts, DzRegions, 0, DzRegions);
-  tuple->H_D_DzSidebands->Sumw2();
 
   // Background prediction histograms don't need to be made for signal or individual MC samples
   // if (!isSignal) {
   // Although not needed let's still do it for every input
   if (true) {
     tuple->H_A = dir.make<TH1D>("H_A", ";NCuts;H_A", NCuts, 0, NCuts);
-    tuple->H_A->Sumw2();
     tuple->H_B = dir.make<TH1D>("H_B", ";NCuts;H_B", NCuts, 0, NCuts);
-    tuple->H_B->Sumw2();
     tuple->H_C = dir.make<TH1D>("H_C", ";NCuts;H_C", NCuts, 0, NCuts);
-    tuple->H_C->Sumw2();
     tuple->H_D = dir.make<TH1D>("H_D", ";NCuts;H_D", NCuts, 0, NCuts);
-    tuple->H_D->Sumw2();
     tuple->H_E = dir.make<TH1D>("H_E", ";NCuts;H_E", NCuts, 0, NCuts);
-    tuple->H_E->Sumw2();
     tuple->H_F = dir.make<TH1D>("H_F", ";NCuts;H_F", NCuts, 0, NCuts);
-    tuple->H_F->Sumw2();
     tuple->H_G = dir.make<TH1D>("H_G", ";NCuts;H_G", NCuts, 0, NCuts);
-    tuple->H_G->Sumw2();
     tuple->H_H = dir.make<TH1D>("H_H", ";NCuts;H_H", NCuts, 0, NCuts);
-    tuple->H_H->Sumw2();
 
     //Initialize histograms for number of bins.  For everything but muon only PredBins=0 so no histograms created
     for (int i = 0; i < PredBins; i++) {
@@ -1337,112 +883,71 @@ void TupleMaker::initializeTuple(Tuple *&tuple,
       Name = "H_B_Binned";
       Name.append(Suffix);
       tuple->H_B_Binned[std::to_string(i)] = dir.make<TH1D>(Name.c_str(), ";NCuts;H_B_Binned", NCuts, 0, NCuts);
-      tuple->H_B_Binned[std::to_string(i)]->Sumw2();
       Name = "H_D_Binned";
       Name.append(Suffix);
       tuple->H_D_Binned[std::to_string(i)] = dir.make<TH1D>(Name.c_str(), ";NCuts;H_D_Binned", NCuts, 0, NCuts);
-      tuple->H_D_Binned[std::to_string(i)]->Sumw2();
       Name = "H_F_Binned";
       Name.append(Suffix);
       tuple->H_F_Binned[std::to_string(i)] = dir.make<TH1D>(Name.c_str(), ";NCuts;H_F_Binned", NCuts, 0, NCuts);
-      tuple->H_F_Binned[std::to_string(i)]->Sumw2();
       Name = "H_H_Binned";
       Name.append(Suffix);
       tuple->H_H_Binned[std::to_string(i)] = dir.make<TH1D>(Name.c_str(), ";NCuts;H_H_Binned", NCuts, 0, NCuts);
-      tuple->H_H_Binned[std::to_string(i)]->Sumw2();
     }
 
     // Where are these used?
       tuple->Hist_Is = dir.make<TH1D>("Hist_Is", "Hist_Is", 200, 0, dEdxS_UpLim);
-    tuple->Hist_Is->Sumw2();
       tuple->Hist_Pt = dir.make<TH1D>("Hist_Pt", "Hist_Pt", 200, 0, PtHistoUpperBound);
-    tuple->Hist_Pt->Sumw2();
       tuple->Hist_TOF = dir.make<TH1D>("Hist_TOF", "Hist_TOF", 200, -10, 20);
-    tuple->Hist_TOF->Sumw2();
     //The following are only used to create the predicted mass spectrum.  Memory intensive so don't initialize for analyses not doing mass fits
     if (TypeMode < 3) {
       tuple->Pred_I = dir.make<TH2F>("Pred_I", ";NCuts;Pred_I", NCuts, 0, NCuts, 400, 0, dEdxM_UpLim);
-      tuple->Pred_I->Sumw2();
       tuple->Pred_EtaI = dir.make<TH3F>("Pred_EtaI", ";NCuts;Pred_EtaI", NCuts, 0, NCuts, EtaBins, -3., 3., 400, 0, dEdxM_UpLim);
-      tuple->Pred_EtaI->Sumw2();
       tuple->Pred_EtaB = dir.make<TH2F>("Pred_EtaB", ";NCuts;Pred_EtaB", NCuts, 0, NCuts, EtaBins, -3., 3.);
-      tuple->Pred_EtaB->Sumw2();
       tuple->Pred_EtaS = dir.make<TH2F>("Pred_EtaS", ";NCuts;Pred_EtaS", NCuts, 0, NCuts, EtaBins, -3., 3.);
-      tuple->Pred_EtaS->Sumw2();
       tuple->Pred_EtaS2 = dir.make<TH2F>("Pred_EtaS2", ";NCuts;Pred_EtaS2", NCuts, 0, NCuts, EtaBins, -3., 3.);
-      tuple->Pred_EtaS2->Sumw2();
       tuple->Pred_EtaP = dir.make<TH3F>("Pred_EtaP", ";NCuts;#eta;P", NCuts, 0, NCuts, EtaBins, -3., 3., 200, GlobalMinPt, PtHistoUpperBound);
-      tuple->Pred_EtaP->Sumw2();
       tuple->Pred_TOF = dir.make<TH2F>("Pred_TOF", ";NCuts;Pred_TOF", NCuts, 0, NCuts, 200, GlobalMinTOF, 5);
-      tuple->Pred_TOF->Sumw2();
       //pz
 
       tuple->PDF_G_EtaP = dir.make<TH3F>("PDF_G_EtaP", ";NCuts;PDF_G_Eta;P", NCuts, 0, NCuts, EtaBins, -3., 3., 200, GlobalMinPt, PtHistoUpperBound);
-      tuple->PDF_G_EtaP->Sumw2();
       tuple->PDF_C_EtaP = dir.make<TH3F>("PDF_C_EtaP", ";NCuts;PDF_C_Eta;P", NCuts, 0, NCuts, EtaBins, -3., 3., 200, GlobalMinPt, PtHistoUpperBound);
-      tuple->PDF_C_EtaP->Sumw2();
 
       tuple->PDF_A_Eta = dir.make<TH2F>("PDF_A_Eta", ";NCuts;PDF_A_Eta", NCuts, 0, NCuts, EtaBins, -3., 3.);
-      tuple->PDF_A_Eta->Sumw2();
       tuple->PDF_E_Eta = dir.make<TH2F>("PDF_E_Eta", ";NCuts;PDF_E_Eta", NCuts, 0, NCuts, EtaBins, -3., 3.);
-      tuple->PDF_E_Eta->Sumw2();
 
       tuple->PDF_B_EtaICK = dir.make<TH3F>("PDF_B_EtaICK", ";NCuts;PDF_B_EtaICK", NCuts, 0, NCuts, EtaBins, -3., 3., 60, -2., 3.);
-      tuple->PDF_B_EtaICK->Sumw2();
       tuple->PDF_F_EtaICK = dir.make<TH3F>("PDF_F_EtaICK", ";NCuts;PDF_F_EtaICK", NCuts, 0, NCuts, EtaBins, -3., 3., 60, -2., 3.);
-      tuple->PDF_F_EtaICK->Sumw2();
 
       tuple->PDF_H_EtaMass = dir.make<TH3F>("PDF_H_EtaMass", ";NCuts;PDF_H_Eta;Mass", NCuts, 0, NCuts, EtaBins, -3., 3., MassNBins, 0, MassHistoUpperBound);
-      tuple->PDF_H_EtaMass->Sumw2();
 
       //pz FLIP
       tuple->PDF_G_EtaP_Flip = dir.make<TH3F>("PDF_G_EtaP_Flip", ";NCuts;PDF_G_EtaP_Flip", NCuts, 0, NCuts, EtaBins, -3., 3., 200, GlobalMinPt, PtHistoUpperBound);
-      tuple->PDF_G_EtaP_Flip->Sumw2();
       tuple->PDF_C_EtaP_Flip = dir.make<TH3F>("PDF_C_EtaP_Flip", ";NCuts;PDF_C_EtaP_Flip", NCuts, 0, NCuts, EtaBins, -3., 3., 200, GlobalMinPt, PtHistoUpperBound);
-      tuple->PDF_C_EtaP_Flip->Sumw2();
 
       tuple->PDF_A_Eta_Flip = dir.make<TH2F>("PDF_A_Eta_Flip", ";NCuts;PDF_A_Eta_Flip", NCuts, 0, NCuts, EtaBins, -3., 3.);
-      tuple->PDF_A_Eta_Flip->Sumw2();
       tuple->PDF_E_Eta_Flip = dir.make<TH2F>("PDF_E_Eta_Flip", ";NCuts;PDF_E_Eta_Flip", NCuts, 0, NCuts, EtaBins, -3., 3.);
-      tuple->PDF_E_Eta_Flip->Sumw2();
 
       tuple->PDF_B_EtaICK_Flip = dir.make<TH3F>("PDF_B_EtaICK_Flip", ";NCuts;PDF_B_EtaICK_Flip", NCuts, 0, NCuts, EtaBins, -3., 3., 60, -2., 3.);
-      tuple->PDF_B_EtaICK_Flip->Sumw2();
       tuple->PDF_F_EtaICK_Flip = dir.make<TH3F>("PDF_F_EtaICK_Flip", ";NCuts;PDF_F_EtaICK_Flip", NCuts, 0, NCuts, EtaBins, -3., 3., 60, -2., 3.);
-      tuple->PDF_F_EtaICK_Flip->Sumw2();
 
       tuple->PDF_H_EtaMass_Flip = dir.make<TH3F>("PDF_H_EtaMass_Flip", ";NCuts;PDF_H_EtaMass_Flip", NCuts, 0, NCuts, EtaBins, -3., 3., MassNBins, 0, MassHistoUpperBound);
-      tuple->PDF_H_EtaMass_Flip->Sumw2();
     }
 
       tuple->RegionD_I = dir.make<TH2F>("RegionD_I", ";NCuts;RegionD_I", NCuts, 0, NCuts, 400, 0, dEdxM_UpLim);
-    tuple->RegionD_I->Sumw2();
       tuple->RegionD_Ias = dir.make<TH2F>("RegionD_Ias", ";NCuts;RegionD_Ias", NCuts, 0, NCuts, 100, 0, dEdxS_UpLim);
-    tuple->RegionD_Ias->Sumw2();
       tuple->RegionD_P = dir.make<TH2F>("RegionD_P", ";NCuts;RegionD_P", NCuts, 0, NCuts, 200, GlobalMinPt, PtHistoUpperBound);
-    tuple->RegionD_P->Sumw2();
       tuple->RegionD_TOF = dir.make<TH2F>("RegionD_TOF", ";NCuts;RegionD_TOF", NCuts, 0, NCuts, 200, GlobalMinTOF, 5);
-    tuple->RegionD_TOF->Sumw2();
 
       tuple->RegionH_Ias = dir.make<TH2F>("RegionH_Ias", ";NCuts;RegionH_Ias", NCuts, 0, NCuts, 100, 0, dEdxS_UpLim);
-    tuple->RegionH_Ias->Sumw2();
 
       tuple->H_A_Flip = dir.make<TH1D>("H_A_Flip", ";NCuts_Flip;H_A_Flip", NCuts_Flip, 0, NCuts_Flip);
-    tuple->H_A_Flip->Sumw2();
       tuple->H_B_Flip = dir.make<TH1D>("H_B_Flip", ";NCuts_Flip;H_B_Flip", NCuts_Flip, 0, NCuts_Flip);
-    tuple->H_B_Flip->Sumw2();
       tuple->H_C_Flip = dir.make<TH1D>("H_C_Flip", ";NCuts_Flip;H_C_Flip", NCuts_Flip, 0, NCuts_Flip);
-    tuple->H_C_Flip->Sumw2();
       tuple->H_D_Flip = dir.make<TH1D>("H_D_Flip", ";NCuts_Flip;H_D_Flip", NCuts_Flip, 0, NCuts_Flip);
-    tuple->H_D_Flip->Sumw2();
       tuple->H_E_Flip = dir.make<TH1D>("H_E_Flip", ";NCuts_Flip;H_E_Flip", NCuts_Flip, 0, NCuts_Flip);
-    tuple->H_E_Flip->Sumw2();
       tuple->H_F_Flip = dir.make<TH1D>("H_F_Flip", ";NCuts_Flip;H_F_Flip", NCuts_Flip, 0, NCuts_Flip);
-    tuple->H_F_Flip->Sumw2();
       tuple->H_G_Flip = dir.make<TH1D>("H_G_Flip", ";NCuts_Flip;H_G_Flip", NCuts_Flip, 0, NCuts_Flip);
-    tuple->H_G_Flip->Sumw2();
       tuple->H_H_Flip = dir.make<TH1D>("H_H_Flip", ";NCuts_Flip;H_H_Flip", NCuts_Flip, 0, NCuts_Flip);
-    tuple->H_H_Flip->Sumw2();
 
     for (int i = 0; i < PredBins; i++) {
       char Suffix[1024];
@@ -1450,127 +955,92 @@ void TupleMaker::initializeTuple(Tuple *&tuple,
       Name = "H_B_Binned_Flip";
       Name.append(Suffix);
       tuple->H_B_Binned_Flip[std::to_string(i)] = dir.make<TH1D>(Name.c_str(), ";NCuts;", NCuts, 0, NCuts);
-      tuple->H_B_Binned_Flip[std::to_string(i)]->Sumw2();
       Name = "H_D_Binned_Flip";
       Name.append(Suffix);
       tuple->H_D_Binned_Flip[std::to_string(i)] = dir.make<TH1D>(Name.c_str(), ";NCuts;", NCuts, 0, NCuts);
-      tuple->H_D_Binned_Flip[std::to_string(i)]->Sumw2();
       Name = "H_F_Binned_Flip";
       Name.append(Suffix);
       tuple->H_F_Binned_Flip[std::to_string(i)] = dir.make<TH1D>(Name.c_str(), ";NCuts;", NCuts, 0, NCuts);
-      tuple->H_F_Binned_Flip[std::to_string(i)]->Sumw2();
       Name = "H_H_Binned_Flip";
       Name.append(Suffix);
       tuple->H_H_Binned_Flip[std::to_string(i)] = dir.make<TH1D>(Name.c_str(), ";NCuts;", NCuts, 0, NCuts);
-      tuple->H_H_Binned_Flip[std::to_string(i)]->Sumw2();
     }
 
     //The following are only used to create the predicted mass spectrum.  Memory intensive so don't initialize for analyses not doing mass fits
     if (TypeMode < 3) {
 
       tuple->Pred_I_Flip = dir.make<TH2F>("Pred_I_Flip", ";NCuts_Flip;Pred_I_Flip", NCuts_Flip, 0, NCuts_Flip, 400, 0, dEdxM_UpLim);
-      tuple->Pred_I_Flip->Sumw2();
 
       tuple->Pred_EtaB_Flip = dir.make<TH2F>("Pred_EtaB_Flip", ";NCuts_Flip;Pred_EtaB_Flip", NCuts_Flip, 0, NCuts_Flip, EtaBins, -3., 3.);
-      tuple->Pred_EtaB_Flip->Sumw2();
 
       tuple->Pred_EtaS_Flip = dir.make<TH2F>("Pred_EtaS_Flip", ";NCuts_Flip;Pred_EtaS_Flip", NCuts_Flip, 0, NCuts_Flip, EtaBins, -3., 3.);
-      tuple->Pred_EtaS_Flip->Sumw2();
 
       tuple->Pred_EtaS2_Flip = dir.make<TH2F>("Pred_EtaS2_Flip", ";NCuts_Flip;Pred_EtaS2_Flip", NCuts_Flip, 0, NCuts_Flip, EtaBins, -3., 3.);
-      tuple->Pred_EtaS2_Flip->Sumw2();
 
       tuple->Pred_EtaP_Flip = dir.make<TH3F>("Pred_EtaP_Flip", ";NCuts_Flip;Pred_EtaP_Flip", NCuts_Flip, 0, NCuts_Flip, EtaBins, -3., 3., 200, GlobalMinPt, PtHistoUpperBound);
-      tuple->Pred_EtaP_Flip->Sumw2();
 
       tuple->Pred_TOF_Flip = dir.make<TH2F>("Pred_TOF_Flip", ";NCuts_Flip;Pred_TOF_Flip", NCuts_Flip, 0, NCuts_Flip, 200, GlobalMinTOF, 5);
-      tuple->Pred_TOF_Flip->Sumw2();
     }
 
 
     tuple->RegionD_I_Flip = dir.make<TH2F>("RegionD_I_Flip", ";NCuts_Flip;RegionD_I_Flip", NCuts_Flip, 0, NCuts_Flip, 400, 0, dEdxM_UpLim);
-    tuple->RegionD_I_Flip->Sumw2();
 
     tuple->RegionD_Ias_Flip =
         dir.make<TH2F>("RegionD_Ias_Flip", ";NCuts_Flip;RegionD_Ias_Flip", NCuts_Flip, 0, NCuts_Flip, 100, 0, dEdxS_UpLim);
-    tuple->RegionD_Ias_Flip->Sumw2();
 
     tuple->RegionD_P_Flip =
         dir.make<TH2F>("RegionD_P_Flip", ";NCuts_Flip;RegionD_P_Flip", NCuts_Flip, 0, NCuts_Flip, 200, GlobalMinPt, PtHistoUpperBound);
-    tuple->RegionD_P_Flip->Sumw2();
 
     tuple->RegionD_TOF_Flip = dir.make<TH2F>("RegionD_TOF_Flip", ";NCuts_Flip;RegionD_TOF_Flip", NCuts_Flip, 0, NCuts_Flip, 200, -3, 1);
-    tuple->RegionD_TOF_Flip->Sumw2();
 
 
     tuple->RegionH_Ias_Flip =
         dir.make<TH2F>("RegionH_Ias_Flip", ";NCuts_Flip;RegionH_Ias_Flip", NCuts_Flip, 0, NCuts_Flip, 100, 0, dEdxS_UpLim);
-    tuple->RegionH_Ias_Flip->Sumw2();
 
 
     tuple->CtrlPt_S1_Is = dir.make<TH1D>("CtrlPt_S1_Is", "CtrlPt_S1_Is", 200, 0, dEdxS_UpLim);
-    tuple->CtrlPt_S1_Is->Sumw2();
 
     tuple->CtrlPt_S2_Is = dir.make<TH1D>("CtrlPt_S2_Is", "CtrlPt_S2_Is", 200, 0, dEdxS_UpLim);
-    tuple->CtrlPt_S2_Is->Sumw2();
 
     tuple->CtrlPt_S3_Is = dir.make<TH1D>("CtrlPt_S3_Is", "CtrlPt_S3_Is", 200, 0, dEdxS_UpLim);
-    tuple->CtrlPt_S3_Is->Sumw2();
 
     tuple->CtrlPt_S4_Is = dir.make<TH1D>("CtrlPt_S4_Is", "CtrlPt_S4_Is", 200, 0, dEdxS_UpLim);
-    tuple->CtrlPt_S4_Is->Sumw2();
 
 
     tuple->CtrlPt_S1_Ih = dir.make<TH1D>("CtrlPt_S1_Ih", "CtrlPt_S1_Ih", 400, 0, dEdxM_UpLim);
-    tuple->CtrlPt_S1_Ih->Sumw2();
 
     tuple->CtrlPt_S2_Ih = dir.make<TH1D>("CtrlPt_S2_Ih", "CtrlPt_S2_Ih", 400, 0, dEdxM_UpLim);
-    tuple->CtrlPt_S2_Ih->Sumw2();
 
     tuple->CtrlPt_S3_Ih = dir.make<TH1D>("CtrlPt_S3_Ih", "CtrlPt_S3_Ih", 400, 0, dEdxM_UpLim);
-    tuple->CtrlPt_S3_Ih->Sumw2();
 
     tuple->CtrlPt_S4_Ih = dir.make<TH1D>("CtrlPt_S4_Ih", "CtrlPt_S4_Ih", 400, 0, dEdxM_UpLim);
-    tuple->CtrlPt_S4_Ih->Sumw2();
 
 
     tuple->CtrlIs_S1_TOF = dir.make<TH1D>("CtrlIs_S1_TOF", "CtrlIs_S1_TOF", 200, 0, 5);
-    tuple->CtrlIs_S1_TOF->Sumw2();
 
     tuple->CtrlIs_S2_TOF = dir.make<TH1D>("CtrlIs_S2_TOF", "CtrlIs_S2_TOF", 200, 0, 5);
-    tuple->CtrlIs_S2_TOF->Sumw2();
 
     tuple->CtrlIs_S3_TOF = dir.make<TH1D>("CtrlIs_S3_TOF", "CtrlIs_S3_TOF", 200, 0, 5);
-    tuple->CtrlIs_S3_TOF->Sumw2();
 
     tuple->CtrlIs_S4_TOF = dir.make<TH1D>("CtrlIs_S4_TOF", "CtrlIs_S4_TOF", 200, 0, 5);
-    tuple->CtrlIs_S4_TOF->Sumw2();
 
 
     tuple->CtrlIh_S1_TOF = dir.make<TH1D>("CtrlIh_S1_TOF", "CtrlIh_S1_TOF", 200, 0, 5);
-    tuple->CtrlIh_S1_TOF->Sumw2();
 
     tuple->CtrlIh_S2_TOF = dir.make<TH1D>("CtrlIh_S2_TOF", "CtrlIh_S2_TOF", 200, 0, 5);
-    tuple->CtrlIh_S2_TOF->Sumw2();
 
     tuple->CtrlIh_S3_TOF = dir.make<TH1D>("CtrlIh_S3_TOF", "CtrlIh_S3_TOF", 200, 0, 5);
-    tuple->CtrlIh_S3_TOF->Sumw2();
 
     tuple->CtrlIh_S4_TOF = dir.make<TH1D>("CtrlIh_S4_TOF", "CtrlIh_S4_TOF", 200, 0, 5);
-    tuple->CtrlIh_S4_TOF->Sumw2();
 
 
     tuple->CtrlPt_S1_TOF = dir.make<TH1D>("CtrlPt_S1_TOF", "CtrlPt_S1_TOF", 200, -2, 7);
-    tuple->CtrlPt_S1_TOF->Sumw2();
 
     tuple->CtrlPt_S2_TOF = dir.make<TH1D>("CtrlPt_S2_TOF", "CtrlPt_S2_TOF", 200, -2, 7);
-    tuple->CtrlPt_S2_TOF->Sumw2();
 
     tuple->CtrlPt_S3_TOF = dir.make<TH1D>("CtrlPt_S3_TOF", "CtrlPt_S3_TOF", 200, -2, 7);
-    tuple->CtrlPt_S3_TOF->Sumw2();
 
     tuple->CtrlPt_S4_TOF = dir.make<TH1D>("CtrlPt_S4_TOF", "CtrlPt_S4_TOF", 200, -2, 7);
-    tuple->CtrlPt_S4_TOF->Sumw2();
 
     for (int i = 0; i < PredBins; i++) {
       char Suffix[1024];
@@ -1578,19 +1048,15 @@ void TupleMaker::initializeTuple(Tuple *&tuple,
 
       Name.append(Suffix);
       tuple->CtrlPt_S1_TOF_Binned[std::to_string(i)] = dir.make<TH1D>("CtrlPt_S1_TOF_Binned", "CtrlPt_S1_TOF_Binned", 200, -2, 7);
-      tuple->CtrlPt_S1_TOF_Binned[std::to_string(i)]->Sumw2();
 
       Name.append(Suffix);
       tuple->CtrlPt_S2_TOF_Binned[std::to_string(i)] = dir.make<TH1D>("CtrlPt_S2_TOF_Binned", "CtrlPt_S2_TOF_Binned", 200, -2, 7);
-      tuple->CtrlPt_S2_TOF_Binned[std::to_string(i)]->Sumw2();
 
       Name.append(Suffix);
       tuple->CtrlPt_S3_TOF_Binned[std::to_string(i)] = dir.make<TH1D>("CtrlPt_S3_TOF_Binned", "CtrlPt_S3_TOF_Binned", 200, -2, 7);
-      tuple->CtrlPt_S3_TOF_Binned[std::to_string(i)]->Sumw2();
 
       Name.append(Suffix);
       tuple->CtrlPt_S4_TOF_Binned[std::to_string(i)] = dir.make<TH1D>("CtrlPt_S4_TOF_Binned", "CtrlPt_S4_TOF_Binned", 200, -2, 7);
-      tuple->CtrlPt_S4_TOF_Binned[std::to_string(i)]->Sumw2();
     }
   }
 


### PR DESCRIPTION
`TH1::SetDefaultSumw2(kTRUE);` does the same thing as doing `->Sumw2()` 534 times

Tested here
https://tvami.web.cern.ch/tvami/projects/HSCP/Histos_BefAutoSumw2_Bin3/BefPreS_Chi2oNdof_logy.png
vs
https://tvami.web.cern.ch/tvami/projects/HSCP/Histos_PostAutoSumw2_Bin3/BefPreS_Chi2oNdof_logy.png
looks identical

also true for the rest of the plots