### PR TITLE
pixel cleaning in Ih, corrections for Gi templates, new dEdX SF, new plots

### DIFF
--- a/Analyzer/interface/CommonFunction.h
+++ b/Analyzer/interface/CommonFunction.h
@@ -2,6 +2,7 @@
 #ifndef SUSYBSMAnalysis_Analyzer_CommonFunction_h
 #define SUSYBSMAnalysis_Analyzer_CommonFunction_h
 
+//#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 //=======================================================================================
 //
 // Global use of the SaturationCorrection class
@@ -1500,6 +1501,7 @@ bool isHitInsideTkModule(const LocalPoint hitPos, const DetId& detid, const SiSt
 }
 
 reco::DeDxData computedEdx(const float& track_eta,
+                           const edm::EventSetup& iSetup,
                            const int& run_number,
                            string year,
                            const reco::DeDxHitInfo* dedxHits,
@@ -1519,7 +1521,14 @@ reco::DeDxData computedEdx(const float& track_eta,
                            bool skipPixelL1 = false,
                            int  skip_templates_ias = 0,
                            bool symmetricSmirnov = false,
-                           bool useMorrisMethod = false) {
+                           bool useMorrisMethod = false,
+                           bool usePixelClusterCleaning = true,
+                           const std::string pixelCPE_ = "",
+                           const TrackerTopology* tTopo = nullptr,
+                           const float& track_px=0,
+                           const float& track_py=0,
+                           const float& track_pz=0,
+                           const int& track_charge=0) {
 
   if (!dedxHits)
     return reco::DeDxData(-1, -1, -1);
@@ -1527,6 +1536,12 @@ reco::DeDxData computedEdx(const float& track_eta,
   std::vector<float> vect;
   std::vector<float> vectStrip;
   std::vector<float> vectPixel;
+
+
+  edm::ESHandle<TrackerGeometry> tkGeometry;
+  iSetup.get<TrackerDigiGeometryRecord>().get(tkGeometry);
+  edm::ESHandle<PixelClusterParameterEstimator> pixelCPE;
+  iSetup.get<TkPixelCPERecord>().get(pixelCPE_, pixelCPE);
 
   // loop in order to have the number of saturated clusters in a track
   unsigned int nsatclust = 0;
@@ -1565,10 +1580,36 @@ reco::DeDxData computedEdx(const float& track_eta,
 
     int ClusterCharge = dedxHits->charge(h);
 
-    // Tav: This really should be done through the topology
-    if (skipPixelL1 && detid.subdetId() == 1 && ((detid >> 20) & 0xF) == 1) //decoding mask for 2017-2018
+//    if (skipPixelL1 && detid.subdetId() == 1 && ((detid >> 20) & 0xF) == 1) //decoding mask for 2017-2018
+    if (skipPixelL1 && detid.subdetId() == 1 && abs(int(tTopo->pxbLayer(detid))) == 1) //decoding mask through the topology
       continue;
 
+//
+    if (detid.subdetId() <3 && usePixelClusterCleaning) { // for pixel only
+         auto const* pixelCluster =  dedxHits->pixelCluster(h);
+         if (pixelCluster == nullptr)  continue;
+         const GeomDetUnit& geomDet = *tkGeometry->idToDetUnit(detid);
+         LocalVector lv = geomDet.toLocal(GlobalVector(track_px, track_py, track_pz));
+         auto reCPE = std::get<2>(pixelCPE->getParameters(*pixelCluster, geomDet, LocalTrajectoryParameters(dedxHits->pos(h), lv, track_charge)));
+         float probQ = SiPixelRecHitQuality::thePacking.probabilityQ(reCPE);
+         float probXY = SiPixelRecHitQuality::thePacking.probabilityXY(reCPE);
+         bool cpeHasFailed = false;
+         if (!SiPixelRecHitQuality::thePacking.hasFilledProb(reCPE)) {
+          cpeHasFailed = true;
+         }
+         if (cpeHasFailed) continue;
+
+        if (probQ <= 0.0 || probQ >= 1.f) probQ = 1.f;
+        if (probXY <= 0.0 || probXY >= 1.f) probXY = 0.f;
+        bool isOnEdge = SiPixelRecHitQuality::thePacking.isOnEdge(reCPE);
+        bool hasBadPixels = SiPixelRecHitQuality::thePacking.hasBadPixels(reCPE);
+        bool spansTwoROCs = SiPixelRecHitQuality::thePacking.spansTwoROCs(reCPE);
+        bool specInCPE = (isOnEdge || hasBadPixels || spansTwoROCs) ? true : false;
+
+        if (specInCPE) continue;
+        if (probQ>0.8) continue;
+
+    }
     if (detid.subdetId() >= 3) {  //for strip only
       
       if(fabs(track_eta) < 1.0 && !(detid.subdetId() == 3 || detid.subdetId() == 5)) continue; // eta < 1.0 -> only TIB+TOB hits

--- a/Analyzer/interface/Tuple.h
+++ b/Analyzer/interface/Tuple.h
@@ -595,6 +595,7 @@ struct Tuple {
   TH3F* Calibration_GiTemplate_PU_4;
   TH3F* Calibration_GiTemplate_PU_5;
 
+
   // Post preselection plots
   TH1F* PostPreS_RelDiffMuonPtAndTrackPt;
   TH2F* PostPreS_MuonPtVsTrackPt;
@@ -719,6 +720,9 @@ struct Tuple {
   TH2F* PostPreS_ProbXYVsProbQ_highIas;
 
   TH1F* PostPreS_Ias_CR;
+  TH1F* PostPreS_Ih_CR;
+  TH1F* PostPreS_Ihstrip_CR;
+  TH1F* PostPreS_Ih_nopixcl_CR;
   TH1F* PostPreS_Pt_lowPt_CR;
   TH1F* PostPreS_Ias_CR_veryLowPt;
   TH1F* PostPreS_P_CR_veryLowPt;
@@ -732,7 +736,17 @@ struct Tuple {
   TH2F* PostPreS_ProbQNoL1VsIas_CR_Ias_down;
   TH2F* PostPreS_ProbQNoL1VsIas_CR_Pt_up;
   TH2F* PostPreS_ProbQNoL1VsIas_CR_Pt_down;
-  
+ 
+  TH1F* PostPreS_Ih_CR_veryLowPt;
+  TH1F* PostPreS_Ihstrip_CR_veryLowPt;
+  TH1F* PostPreS_Ih_noclean_CR_veryLowPt;
+  TH1F* PostPreS_Ih_noinside_CR_veryLowPt;
+  TH1F* PostPreS_Ih_nopixcl_CR_veryLowPt;
+  TH1F* PostPreS_Pt_CR_veryLowPt; 
+  TH1F* PostPreS_ProbQNoL1_CR_veryLowPt; 
+  TH2F* PostPreS_CpPL_pix_CR_veryLowPt;
+  TH2F* PostPreS_CpPL_strip_CR_veryLowPt;
+
   TH1F* PostS_RelativePtShift;
   TH1F* PostS_ProbQNoL1;
   TH1F* PostS_Ias;
@@ -1388,6 +1402,8 @@ struct Tuple {
  TH2D* SF_HHit2DStrip_loose;
  TH2D* SF_HHit2DPix;
  TH2D* SF_HHit2DStrip;
+ TH2D* SF_HHit2DPix_nosf;
+ TH2D* SF_HHit2DStrip_nosf;
 
  // K and C
  TH2D* K_and_C_Ih_noL1_VsP_loose1;
@@ -1411,10 +1427,13 @@ struct Tuple {
  TH2D* K_and_C_Ih_noL1_VsP_noFcut2;
  TH2D* K_and_C_Ih_strip_VsP_noFcut1;
  TH2D* K_and_C_Ih_strip_VsP_noFcut2;
- TH1D* K_and_C_Kin_Mass;
- TH1D* K_and_C_Kin_p;
- TH1D* K_and_C_Kin_phi;
- TH1D* K_and_C_Kin_eta;
+ TH1F* K_and_C_Kin_Mass;
+ TH1F* K_and_C_Kin_p;
+ TH1F* K_and_C_Kin_phi;
+ TH1F* K_and_C_Kin_eta;
+
+ TH1F* K_and_C_nsat;
+ TH1F* K_and_C_fracsat;
 
 
  // Stability
@@ -1427,6 +1446,10 @@ struct Tuple {
  TH2D* Stab_invB_VsRun;
  TH2D* Stab_invB_DT_VsRun;
  TH2D* Stab_invB_CSC_VsRun;
+
+ // Saturatopm
+ TH1F* Sat_nsat;
+ TH1F* Sat_fracsat;
 };
 
 #endif

--- a/Analyzer/interface/TupleMaker.h
+++ b/Analyzer/interface/TupleMaker.h
@@ -1078,6 +1078,9 @@ void TupleMaker::initializeTuple(Tuple *&tuple,
     tuple->PostPreS_Pt_lowPt = dir.make<TH1F>("PostPreS_Pt_lowPt", ";p_{T} (GeV);Tracks / 10 GeV", 50, 0., 500.);
     tuple->PostPreS_PtVsIas = dir.make<TH2F>("PostPreS_PtVsIas",";p_{T};G_{i}^{strips};Tracks / 80 GeV", 40, 0., PtHistoUpperBound, 20, 0., 1.);
     tuple->PostPreS_Ias_CR = dir.make<TH1F>("PostPreS_Ias_CR", ";G_{i}^{strips};Tracks / 0.1", 10, 0, dEdxS_UpLim);
+    tuple->PostPreS_Ih_CR= dir.make<TH1F>("PostPreS_Ih_CR", ";I_{h} (MeV/cm)", 200, 0, dEdxM_UpLim);
+    tuple->PostPreS_Ihstrip_CR= dir.make<TH1F>("PostPreS_Ihstrip_CR", ";I_{h} (strip only) (MeV/cm)", 200, 0, dEdxM_UpLim);
+    tuple->PostPreS_Ih_nopixcl_CR= dir.make<TH1F>("PostPreS_Ih_nopixcl_CR", ";I_{h}(no pix cleaning) (MeV/cm)", 200, 0, dEdxM_UpLim);
     tuple->PostPreS_Pt_lowPt_CR = dir.make<TH1F>("PostPreS_Pt_lowPt_CR", ";p_{T} (GeV);Tracks / 10 GeV", 50, 0., 500.);
     tuple->PostPreS_Ias_CR_veryLowPt = dir.make<TH1F>("PostPreS_Ias_CR_veryLowPt", ";G_{i}^{strips};Tracks / 0.1", 10, 0, dEdxS_UpLim);
     tuple->PostPreS_P_CR_veryLowPt = dir.make<TH1F>("PostPreS_P_CR_veryLowPt", ";p (GeV);Tracks / 10 GeV", 50, 0., 50);
@@ -1367,6 +1370,19 @@ void TupleMaker::initializeTuple(Tuple *&tuple,
     tuple->PostPreS_RecoPfJetsNum = dir.make<TH1F>("PostPreS_RecoPfJetsNum", ";Number of PF jets;Tracks / 1",  15, -0.5, 15.5);
     tuple->PostPreS_RecoPfHT = dir.make<TH1F>("PostPreS_RecoPfHT", ";PfHT",100,0.,2000.);
     tuple->PostPreS_GenBeta = dir.make<TH1F>("PostPreS_GenBeta", ";#beta;Gen candidate / 0.05", 20, 0., 1.);
+
+
+    // add  plots in Gitemplate region  to answer Slava's questions
+     tuple->PostPreS_CpPL_pix_CR_veryLowPt = dir.make<TH2F>("PostPreS_CpPL_pix_CR_veryLowPt","PostPreS_CpPL_pix_CR_veryLowPt",100,0,10,10,0,10);
+     tuple->PostPreS_CpPL_strip_CR_veryLowPt = dir.make<TH2F>("PostPreS_CpPL_strip_CR_veryLowPt","PostPreS_CpPL_strip_CR_veryLowPt",100,0,10,25,0,25);
+     tuple->PostPreS_Ih_CR_veryLowPt = dir.make<TH1F>("PostPreS_Ih_CR_veryLowPt", ";I_{h} (MeV/cm)", 200, 0, dEdxM_UpLim);
+     tuple->PostPreS_Ihstrip_CR_veryLowPt = dir.make<TH1F>("PostPreS_Ihstrip_CR_veryLowPt", ";I_{h} (strip only) (MeV/cm)", 200, 0, dEdxM_UpLim);
+     tuple->PostPreS_Ih_noclean_CR_veryLowPt = dir.make<TH1F>("PostPreS_Ih_noclean_CR_veryLowPt", ";I_{h}(no cleaning) (MeV/cm)", 200, 0, dEdxM_UpLim);
+     tuple->PostPreS_Ih_noinside_CR_veryLowPt = dir.make<TH1F>("PostPreS_Ih_noinside_CR_veryLowPt", ";I_{h}(no clean no inside) (MeV/cm)", 200, 0, dEdxM_UpLim);
+     tuple->PostPreS_Ih_nopixcl_CR_veryLowPt = dir.make<TH1F>("PostPreS_Ih_nopixcl_CR_veryLowPt", ";I_{h}(no pix cleaning) (MeV/cm)", 200, 0, dEdxM_UpLim);
+     tuple->PostPreS_Pt_CR_veryLowPt = dir.make<TH1F>("PostPreS_Pt_CR_veryLowPt", ";p_{T} (GeV)", 50, 0., 50.);
+     tuple->PostPreS_ProbQNoL1_CR_veryLowPt = dir.make<TH1F>("PostPreS_ProbQNoL1_CR_veryLowPt", ";F_{i}^{pixels}", 20, 0., 1.);
+
   }
   tuple->PostS_HltMatchTrackLevel = dir.make<TH1F>("PostS_HltMatchTrackLevel", ";;Events / category", 3, 0.5, 3.5);
   tuple->PostS_HltMatchTrackLevel->GetXaxis()->SetBinLabel(1,"HLT + any muon match");
@@ -1879,6 +1895,8 @@ void TupleMaker::initializeTuple(Tuple *&tuple,
     tuple->SF_HHit2DStrip_loose =  dir.make<TH2D>("SF_HHit2DStrip_loose", "SF_HHit2DStrip_loose",  50, 0., 100., 200, 0., 20.);
     tuple->SF_HHit2DPix   =  dir.make<TH2D>("SF_HHit2DPix", "SF_HHit2DPix",  50, 0., 100., 200, 0., 20.);
     tuple->SF_HHit2DStrip =  dir.make<TH2D>("SF_HHit2DStrip", "SF_HHit2DStrip",  50, 0., 100., 200, 0., 20.);
+    tuple->SF_HHit2DPix_nosf   =  dir.make<TH2D>("SF_HHit2DPix_nosf", "SF_HHit2DPix_nosf",  50, 0., 100., 200, 0., 20.);
+    tuple->SF_HHit2DStrip_nosf =  dir.make<TH2D>("SF_HHit2DStrip_nosf", "SF_HHit2DStrip_nosf",  50, 0., 100., 200, 0., 20.);
 
   // K and C
     tuple->K_and_C_Ih_noL1_VsP_loose1 = dir.make<TH2D>("K_and_C_Ih_noL1_VsP_loose1","K_and_C_Ih_noL1_VsP_loose1", 50,0,5, 80, 2.,10.);
@@ -1903,10 +1921,13 @@ void TupleMaker::initializeTuple(Tuple *&tuple,
     tuple->K_and_C_Ih_strip_VsP_noFcut1 = dir.make<TH2D>("K_and_C_Ih_strip_VsP_noFcut1","K_and_C_Ih_strip_VsP_noFcut1", 50,0,5, 80, 2.,10.);
     tuple->K_and_C_Ih_strip_VsP_noFcut2 = dir.make<TH2D>("K_and_C_Ih_strip_VsP_noFcut2","K_and_C_Ih_strip_VsP_noFcut2", 250,0,50, 80, 2.,10.);
 
-    tuple->K_and_C_Kin_Mass = dir.make<TH1D>("K_and_C_Kin_Mass","K_and_C_Kin_Mass",100,0.,5.);
-    tuple->K_and_C_Kin_p = dir.make<TH1D>("K_and_C_Kin_p","K_and_C_Kin_p",50,0.,5.);
-    tuple->K_and_C_Kin_phi = dir.make<TH1D>("K_and_C_Kin_phi","K_and_C_Kin_phi",  24, -1.*acos(-1),acos(-1));
-    tuple->K_and_C_Kin_eta = dir.make<TH1D>("K_and_C_Kin_eta","K_and_C_Kin_eta", 18, -2.25, 2.25);
+    tuple->K_and_C_Kin_Mass = dir.make<TH1F>("K_and_C_Kin_Mass","K_and_C_Kin_Mass",100,0.,5.);
+    tuple->K_and_C_Kin_p = dir.make<TH1F>("K_and_C_Kin_p","K_and_C_Kin_p",50,0.,5.);
+    tuple->K_and_C_Kin_phi = dir.make<TH1F>("K_and_C_Kin_phi","K_and_C_Kin_phi",  24, -1.*acos(-1),acos(-1));
+    tuple->K_and_C_Kin_eta = dir.make<TH1F>("K_and_C_Kin_eta","K_and_C_Kin_eta", 18, -2.25, 2.25);
+
+    tuple->K_and_C_nsat = dir.make<TH1F>("K_and_C_nsat","K_and_C_nsat", 11, -0.5, 10.5);
+    tuple->K_and_C_fracsat = dir.make<TH1F>("K_and_C_fracsat","K_and_C_fracsat", 50, 0., 1.);
 
   // Stability
     tuple->Stab_Ih_NoL1_VsRun    = dir.make<TH2D>("Stab_Ih_NoL1_VsRun","Ih(NoL1):Run", 545, 271000,325500, 60, 0.,15.);
@@ -1919,6 +1940,9 @@ void TupleMaker::initializeTuple(Tuple *&tuple,
     tuple->Stab_invB_DT_VsRun    = dir.make<TH2D>("Stab_invB_DT_VsRun","invBeta(DT):Run", 545, 271000,325500, 90,-1,2);
     tuple->Stab_invB_CSC_VsRun   = dir.make<TH2D>("Stab_invB_CSC_VsRun","invBeta(CSC):Run", 545, 271000,325500, 90,-1,2);
 
+  // saturation
+    tuple->Sat_nsat = dir.make<TH1F>("Sat_nsat","Sat_nsat", 11, -0.5, 10.5);
+    tuple->Sat_fracsat = dir.make<TH1F>("Sat_fracsat","Sat_fracsat", 50, 0., 1.);
 
 
   }

--- a/Analyzer/plugins/Analyzer.cc
+++ b/Analyzer/plugins/Analyzer.cc
@@ -2290,9 +2290,12 @@ for ( int q=0; q<MAX_MuonHLTFilters;q++) {
   
     float Fmip = (float)nofClust_dEdxLowerThan / (float)dedxHits->size();
 
-    //computedEdx: hits, SF, templates, usePixel, useStrips,, useClusterCleaning, uneTrunc,
-    //             mustBeInside, MaxStripNOM, correctFEDSat, XtalkInv, lowDeDxDrop, dedxErr, useTemplateLayer_, skip_templates_ias, useMorrisMethod
-    //
+    //computedEdx: track_eta, iSetup, run, year, 
+    //             hits, SF, templates, usePixel, useStrips,, useClusterCleaning, uneTrunc,
+    //             mustBeInside, MaxStripNOM, correctFEDSat, XtalkInv, lowDeDxDrop, dedxErr, useTemplateLayer_, 
+    //             skipPixelL1, skip_templates_ias, useMorrisMethod,
+    //             usePixelClusterCleaning,pixelCPE_,tTopo,track_px,track_py,track_pz,track_charge
+    ///
     //correction inverseXtalk = 0 --> take the raw amplitudes of the cluster
     //correction inverseXtalk = 1 --> modify the amplitudes based on xtalk for non-saturated cluster + correct for saturation
     //
@@ -2307,15 +2310,17 @@ for ( int q=0; q<MAX_MuonHLTFilters;q++) {
 
     // Ih
     auto dedxMObj_FullTrackerTmp =
-        computedEdx(track->eta(),run_number, year, dedxHits, dEdxSF, localdEdxTemplates = nullptr, usePixel = true,  useStrip = true, useClusterCleaning, useTruncated = false,
-                    mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, &dEdxErr, useTemplateLayer_);
+        computedEdx(track->eta(),iSetup, run_number, year, dedxHits, dEdxSF, localdEdxTemplates = nullptr, usePixel = true,  useStrip = true, useClusterCleaning, useTruncated = false,
+                    mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, &dEdxErr, useTemplateLayer_,
+                    false,0, false, false, true, pixelCPE_, tTopo, track->px(), track->py(), track->pz(), track->charge());
 
     reco::DeDxData* dedxMObj_FullTracker = dedxMObj_FullTrackerTmp.numberOfMeasurements() > 0 ? &dedxMObj_FullTrackerTmp : nullptr;
 
     // Ih Up
     auto dedxMUpObjTmp =
-        computedEdx(track->eta(),run_number, year, dedxHits, dEdxSF, localdEdxTemplates = nullptr, usePixel = true, useStrip = true, useClusterCleaning, useTruncated = false,
-                    mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.15, 0, useTemplateLayer_);
+        computedEdx(track->eta(), iSetup, run_number, year, dedxHits, dEdxSF, localdEdxTemplates = nullptr, usePixel = true, useStrip = true, useClusterCleaning, useTruncated = false,
+                    mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.15, 0, useTemplateLayer_,
+                    false,0, false, false, true,  pixelCPE_, tTopo, track->px(), track->py(), track->pz(), track->charge());
 
     reco::DeDxData* dedxMUpObj = dedxMUpObjTmp.numberOfMeasurements() > 0 ? &dedxMUpObjTmp : nullptr;
 
@@ -2323,51 +2328,59 @@ for ( int q=0; q<MAX_MuonHLTFilters;q++) {
     // For now it's a copy of Ih Up, I doubt that's what it should be...
     // Also I think this should be done on the top of Ih no pixel L1 not the full tracker version
     auto dedxMDownObjTmp =
-        computedEdx(track->eta(),run_number, year, dedxHits, dEdxSF, localdEdxTemplates = nullptr, usePixel = true, useStrip = true, useClusterCleaning, useTruncated = false,
-                    mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.15, 0, useTemplateLayer_);
+        computedEdx(track->eta(), iSetup, run_number, year, dedxHits, dEdxSF, localdEdxTemplates = nullptr, usePixel = true, useStrip = true, useClusterCleaning, useTruncated = false,
+                    mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.15, 0, useTemplateLayer_,
+                    false,0, false, false, true, pixelCPE_, tTopo, track->px(), track->py(), track->pz(), track->charge());
 
     reco::DeDxData* dedxMDownObj = dedxMDownObjTmp.numberOfMeasurements() > 0 ? &dedxMDownObjTmp : nullptr;
 
+///=====> THE GOLDEN VARIABLE : 
     // Ih no pixel L1
     auto dedxIh_noL1_Tmp =
-        computedEdx(track->eta(),run_number, year, dedxHits, dEdxSF, localdEdxTemplates = nullptr, usePixel = true, useStrip = true, useClusterCleaning, useTruncated = false,
-                    mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, &dEdxErr, useTemplateLayer_, skipPixelL1 = true);
+        computedEdx(track->eta(), iSetup, run_number, year, dedxHits, dEdxSF, localdEdxTemplates = nullptr, usePixel = true, useStrip = true, useClusterCleaning, useTruncated = false,
+                    mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, &dEdxErr, useTemplateLayer_, skipPixelL1 = true,
+                    0, false, false, true, pixelCPE_, tTopo, track->px(), track->py(), track->pz(), track->charge());
 
     reco::DeDxData* dedxIh_noL1 = dedxIh_noL1_Tmp.numberOfMeasurements() > 0 ? &dedxIh_noL1_Tmp : nullptr;
 
     // Ih 0.15 low values drop
     // Should useTruncated be true ?
     auto dedxIh_15drop_Tmp =
-        computedEdx(track->eta(),run_number, year, dedxHits, dEdxSF, localdEdxTemplates = nullptr, usePixel = true, useStrip = true, useClusterCleaning, useTruncated = true,
-                    mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.15, &dEdxErr, useTemplateLayer_);
+        computedEdx(track->eta(),iSetup, run_number, year, dedxHits, dEdxSF, localdEdxTemplates = nullptr, usePixel = true, useStrip = true, useClusterCleaning, useTruncated = true,
+                    mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.15, &dEdxErr, useTemplateLayer_,
+                    false,0, false, false, true,  pixelCPE_, tTopo, track->px(), track->py(), track->pz(), track->charge());
 
     reco::DeDxData* dedxIh_15drop = dedxIh_15drop_Tmp.numberOfMeasurements() > 0 ? &dedxIh_15drop_Tmp : nullptr;
 
     // Ih Strip only
     auto dedxIh_StripOnly_Tmp =
-        computedEdx(track->eta(),run_number, year, dedxHits, dEdxSF, localdEdxTemplates = nullptr, usePixel = false, useStrip = true, useClusterCleaning, useTruncated = false,
-                    mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, &dEdxErr, useTemplateLayer_);
+        computedEdx(track->eta(), iSetup, run_number, year, dedxHits, dEdxSF, localdEdxTemplates = nullptr, usePixel = false, useStrip = true, useClusterCleaning, useTruncated = false,
+                    mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, &dEdxErr, useTemplateLayer_,
+                    false,0, false, false, true, pixelCPE_, tTopo, track->px(), track->py(), track->pz(), track->charge());
 
     reco::DeDxData* dedxIh_StripOnly = dedxIh_StripOnly_Tmp.numberOfMeasurements() > 0 ? &dedxIh_StripOnly_Tmp : nullptr;
 
     // Ih Strip only and 0.15 low values drop
     auto dedxIh_StripOnly_15drop_Tmp =
-        computedEdx(track->eta(),run_number, year, dedxHits, dEdxSF, localdEdxTemplates = nullptr, usePixel = false, useStrip = true, useClusterCleaning, useTruncated = true,
-                    mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.15, &dEdxErr, useTemplateLayer_, skipPixelL1 = true);
+        computedEdx(track->eta(), iSetup, run_number, year, dedxHits, dEdxSF, localdEdxTemplates = nullptr, usePixel = false, useStrip = true, useClusterCleaning, useTruncated = true,
+                    mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.15, &dEdxErr, useTemplateLayer_, skipPixelL1 = true,
+                    0, false, false, true, pixelCPE_, tTopo, track->px(), track->py(), track->pz(), track->charge());
 
     reco::DeDxData* dedxIh_StripOnly_15drop = dedxIh_StripOnly_15drop_Tmp.numberOfMeasurements() > 0 ? &dedxIh_StripOnly_15drop_Tmp : nullptr;
 
     // Ih Pixel only no BPIXL1
     auto dedxIh_PixelOnly_noL1_Tmp =
-        computedEdx(track->eta(),run_number, year, dedxHits, dEdxSF, localdEdxTemplates = nullptr, usePixel = true, useStrip = false, useClusterCleaning, useTruncated = false,
-                    mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, &dEdxErr, useTemplateLayer_, skipPixelL1 = true);
+        computedEdx(track->eta(), iSetup, run_number, year, dedxHits, dEdxSF, localdEdxTemplates = nullptr, usePixel = true, useStrip = false, useClusterCleaning, useTruncated = false,
+                    mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, &dEdxErr, useTemplateLayer_, skipPixelL1 = true,
+                    0, false, false, true,  pixelCPE_, tTopo, track->px(), track->py(), track->pz(), track->charge());
 
     reco::DeDxData* dedxIh_PixelOnlyh_noL1 = dedxIh_PixelOnly_noL1_Tmp.numberOfMeasurements() > 0 ? &dedxIh_PixelOnly_noL1_Tmp : nullptr;
 
     // Ih correct saturation from fits
     auto dedxIh_SaturationCorrectionFromFits_Tmp =
-        computedEdx(track->eta(),run_number, year, dedxHits, dEdxSF, localdEdxTemplates = nullptr, usePixel = false, useStrip = true, useClusterCleaning, useTruncated = false,
-                    mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 2, dropLowerDeDxValue = 0.0, &dEdxErr, useTemplateLayer_, skipPixelL1 = true);
+        computedEdx(track->eta(), iSetup, run_number, year, dedxHits, dEdxSF, localdEdxTemplates = nullptr, usePixel = false, useStrip = true, useClusterCleaning, useTruncated = false,
+                    mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 2, dropLowerDeDxValue = 0.0, &dEdxErr, useTemplateLayer_, skipPixelL1 = true,
+                    0, false, false, true, pixelCPE_, tTopo, track->px(), track->py(), track->pz(), track->charge());
 
     reco::DeDxData* dedxIh_SaturationCorrectionFromFits = dedxIh_SaturationCorrectionFromFits_Tmp.numberOfMeasurements() > 0 ? &dedxIh_SaturationCorrectionFromFits_Tmp : nullptr;
 
@@ -2392,52 +2405,60 @@ for ( int q=0; q<MAX_MuonHLTFilters;q++) {
     int NPV = vertexColl.size();
     if(!puTreatment_) {
         dedxIas_FullTrackerTmp =
-        computedEdx(track->eta(),run_number, year, dedxHits, dEdxSF, localdEdxTemplates = dEdxTemplates, usePixel = true, useStrip = true, useClusterCleaning, useTruncated = false,
-                   mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, 0, useTemplateLayer_);
+        computedEdx(track->eta(), iSetup, run_number, year, dedxHits, dEdxSF, localdEdxTemplates = dEdxTemplates, usePixel = true, useStrip = true, useClusterCleaning, useTruncated = false,
+                   mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, 0, useTemplateLayer_,
+                   false,0, false, false, true, pixelCPE_, tTopo, track->px(), track->py(), track->pz(), track->charge());
 
         dedxIas_FullTracker = dedxIas_FullTrackerTmp.numberOfMeasurements() > 0 ? &dedxIas_FullTrackerTmp : nullptr;
 
         dedxIas_noL1Tmp =
-        computedEdx(track->eta(),run_number, year, dedxHits, dEdxSF, localdEdxTemplates = dEdxTemplates, usePixel = true, useStrip = true, useClusterCleaning, useTruncated = false,
-               mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, 0, useTemplateLayer_,skipPixelL1 = true, skip_templates_ias = 2);
+        computedEdx(track->eta(), iSetup, run_number, year, dedxHits, dEdxSF, localdEdxTemplates = dEdxTemplates, usePixel = true, useStrip = true, useClusterCleaning, useTruncated = false,
+               mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, 0, useTemplateLayer_,skipPixelL1 = true, skip_templates_ias = 2,
+                   false, false, true, pixelCPE_, tTopo, track->px(), track->py(), track->pz(), track->charge());
 
         dedxIas_noL1 = dedxIas_noL1Tmp.numberOfMeasurements() > 0 ? &dedxIas_noL1Tmp : nullptr;
 
         dedxIas_noTIBnoTIDno3TEC_Tmp =
-        computedEdx(track->eta(),run_number, year, dedxHits, dEdxSF, localdEdxTemplates = dEdxTemplates, usePixel = true, useStrip = true, useClusterCleaning, useTruncated = false,
-                    mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, 0, useTemplateLayer_, skipPixelL1 = true, skip_templates_ias = 1);
+        computedEdx(track->eta(), iSetup, run_number, year, dedxHits, dEdxSF, localdEdxTemplates = dEdxTemplates, usePixel = true, useStrip = true, useClusterCleaning, useTruncated = false,
+                    mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, 0, useTemplateLayer_, skipPixelL1 = true, skip_templates_ias = 1,
+                    false, false, true, pixelCPE_, tTopo, track->px(), track->py(), track->pz(), track->charge());
 
 
         dedxIas_noTIBnoTIDno3TEC = dedxIas_noTIBnoTIDno3TEC_Tmp.numberOfMeasurements() > 0 ? &dedxIas_noTIBnoTIDno3TEC_Tmp : nullptr;
 
         dedxIas_PixelOnly_Tmp =
-        computedEdx(track->eta(),run_number, year, dedxHits, dEdxSF, localdEdxTemplates = dEdxTemplates, usePixel = true, useStrip = false, useClusterCleaning, useTruncated = false,
-                    mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, 0, useTemplateLayer_, skipPixelL1 = false, skip_templates_ias = 2);
+        computedEdx(track->eta(), iSetup, run_number, year, dedxHits, dEdxSF, localdEdxTemplates = dEdxTemplates, usePixel = true, useStrip = false, useClusterCleaning, useTruncated = false,
+                    mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, 0, useTemplateLayer_, skipPixelL1 = false, skip_templates_ias = 2,
+                    false, false, true,  pixelCPE_, tTopo, track->px(), track->py(), track->pz(), track->charge());
 
         dedxIas_PixelOnly = dedxIas_PixelOnly_Tmp.numberOfMeasurements() > 0 ? &dedxIas_PixelOnly_Tmp : nullptr;
 
         dedxIas_StripOnly_Tmp =
-        computedEdx(track->eta(),run_number, year, dedxHits, dEdxSF, localdEdxTemplates = dEdxTemplates, usePixel = false, useStrip = true, useClusterCleaning, useTruncated = false,
-                    mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, 0, useTemplateLayer_, skipPixelL1 = false, skip_templates_ias = 0);
+        computedEdx(track->eta(), iSetup, run_number, year, dedxHits, dEdxSF, localdEdxTemplates = dEdxTemplates, usePixel = false, useStrip = true, useClusterCleaning, useTruncated = false,
+                    mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, 0, useTemplateLayer_, skipPixelL1 = false, skip_templates_ias = 0,
+                    false, false, true,  pixelCPE_, tTopo, track->px(), track->py(), track->pz(), track->charge());
 
         dedxIas_StripOnly = dedxIas_StripOnly_Tmp.numberOfMeasurements() > 0 ? &dedxIas_StripOnly_Tmp : nullptr;
 
         dedxIas_PixelOnly_noL1_Tmp =
-        computedEdx(track->eta(),run_number, year, dedxHits, dEdxSF, localdEdxTemplates = dEdxTemplates, usePixel = true, useStrip = false, useClusterCleaning, useTruncated = false,
-                    mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, 0, useTemplateLayer_, skipPixelL1 = true, skip_templates_ias = 2);
+        computedEdx(track->eta(), iSetup, run_number, year, dedxHits, dEdxSF, localdEdxTemplates = dEdxTemplates, usePixel = true, useStrip = false, useClusterCleaning, useTruncated = false,
+                    mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, 0, useTemplateLayer_, skipPixelL1 = true, skip_templates_ias = 2,
+                    false, false, true,  pixelCPE_, tTopo, track->px(), track->py(), track->pz(), track->charge());
 
         dedxIas_PixelOnly_noL1 = dedxIas_PixelOnly_noL1_Tmp.numberOfMeasurements() > 0 ? &dedxIas_PixelOnly_noL1_Tmp : nullptr;
 
         dedxIs_StripOnly_Tmp =
-    computedEdx(track->eta(),run_number, year, dedxHits, dEdxSF, localdEdxTemplates = dEdxTemplates, usePixel = true, useStrip = false, useClusterCleaning, useTruncated = false,
-                mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, 0, useTemplateLayer_, skipPixelL1 = true, skip_templates_ias = 2, symmetricSmirnov = true);
+    computedEdx(track->eta(), iSetup, run_number, year, dedxHits, dEdxSF, localdEdxTemplates = dEdxTemplates, usePixel = true, useStrip = false, useClusterCleaning, useTruncated = false,
+                mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, 0, useTemplateLayer_, skipPixelL1 = true, skip_templates_ias = 2, symmetricSmirnov = true,
+                false, true,  pixelCPE_, tTopo, track->px(), track->py(), track->pz(), track->charge());
 
         dedxIs_StripOnly = dedxIs_StripOnly_Tmp.numberOfMeasurements() > 0 ? &dedxIs_StripOnly_Tmp : nullptr;
       
       // the FiStrips variable
       dedxMorrisMethod_StripOnly_Tmp =
-      computedEdx(track->eta(),run_number, year, dedxHits, dEdxSF, localdEdxTemplates = dEdxTemplates, usePixel = false, useStrip = true, useClusterCleaning, useTruncated = false,
-                  mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, 0, useTemplateLayer_, skipPixelL1 = false, skip_templates_ias = 0, symmetricSmirnov = false, useMorrisMethod = true);
+      computedEdx(track->eta(), iSetup, run_number, year, dedxHits, dEdxSF, localdEdxTemplates = dEdxTemplates, usePixel = false, useStrip = true, useClusterCleaning, useTruncated = false,
+                  mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, 0, useTemplateLayer_, skipPixelL1 = false, skip_templates_ias = 0, 
+                  symmetricSmirnov = false, useMorrisMethod = true, true, pixelCPE_, tTopo, track->px(), track->py(), track->pz(), track->charge() );
       
       dedxMorrisMethod_StripOnly = dedxMorrisMethod_StripOnly_Tmp.numberOfMeasurements() > 0 ? &dedxMorrisMethod_StripOnly_Tmp : nullptr;
       } else {
@@ -2445,57 +2466,65 @@ for ( int q=0; q<MAX_MuonHLTFilters;q++) {
             if ( NPV > PuBins_[i] && NPV <= PuBins_[i+1] ){
                 //globalIas_
                 dedxIas_FullTrackerTmp =
-                computedEdx(track->eta(),run_number, year, dedxHits, dEdxSF, localdEdxTemplates = dEdxTemplatesPU[i], usePixel = true, useStrip = true, useClusterCleaning, useTruncated = false,
-                            mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, 0, useTemplateLayer_);
+                computedEdx(track->eta(), iSetup, run_number, year, dedxHits, dEdxSF, localdEdxTemplates = dEdxTemplatesPU[i], usePixel = true, useStrip = true, useClusterCleaning, useTruncated = false,
+                            mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, 0, useTemplateLayer_,
+                            false,0, false, false, true, pixelCPE_, tTopo, track->px(), track->py(), track->pz(), track->charge());
 
                 dedxIas_FullTracker = dedxIas_FullTrackerTmp.numberOfMeasurements() > 0 ? &dedxIas_FullTrackerTmp : nullptr;
 
                 //globalIas_ no BPIXL1
                 dedxIas_noL1Tmp =
-                computedEdx(track->eta(),run_number, year, dedxHits, dEdxSF, localdEdxTemplates = dEdxTemplatesPU[i], usePixel = true, useStrip = true, useClusterCleaning, useTruncated = false,
-                       mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, 0, useTemplateLayer_,skipPixelL1 = true, skip_templates_ias = 2);
+                computedEdx(track->eta(), iSetup, run_number, year, dedxHits, dEdxSF, localdEdxTemplates = dEdxTemplatesPU[i], usePixel = true, useStrip = true, useClusterCleaning, useTruncated = false,
+                       mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, 0, useTemplateLayer_,skipPixelL1 = true, skip_templates_ias = 2,
+                             false, false, true, pixelCPE_, tTopo, track->px(), track->py(), track->pz(), track->charge());
 
                 dedxIas_noL1 = dedxIas_noL1Tmp.numberOfMeasurements() > 0 ? &dedxIas_noL1Tmp : nullptr;
 
                 //globalIas_ without TIB, TID, and 3 first TEC layers
                 dedxIas_noTIBnoTIDno3TEC_Tmp =
-                    computedEdx(track->eta(),run_number, year, dedxHits, dEdxSF, localdEdxTemplates = dEdxTemplatesPU[i], usePixel = true, useStrip = true, useClusterCleaning, useTruncated = false,
-                                mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, 0, useTemplateLayer_, skipPixelL1 = true, skip_templates_ias = 1);
+                    computedEdx(track->eta(), iSetup, run_number, year, dedxHits, dEdxSF, localdEdxTemplates = dEdxTemplatesPU[i], usePixel = true, useStrip = true, useClusterCleaning, useTruncated = false,
+                                mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, 0, useTemplateLayer_, skipPixelL1 = true, skip_templates_ias = 1,
+                             false, false, true, pixelCPE_, tTopo, track->px(), track->py(), track->pz(), track->charge());
 
                 dedxIas_noTIBnoTIDno3TEC = dedxIas_noTIBnoTIDno3TEC_Tmp.numberOfMeasurements() > 0 ? &dedxIas_noTIBnoTIDno3TEC_Tmp : nullptr;
 
                 //globalIas_ Pixel only
                 dedxIas_PixelOnly_Tmp =
-                    computedEdx(track->eta(),run_number, year, dedxHits, dEdxSF, localdEdxTemplates = dEdxTemplatesPU[i], usePixel = true, useStrip = false, useClusterCleaning, useTruncated = false,
-                                mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, 0, useTemplateLayer_, skipPixelL1 = false, skip_templates_ias = 2);
+                    computedEdx(track->eta(), iSetup, run_number, year, dedxHits, dEdxSF, localdEdxTemplates = dEdxTemplatesPU[i], usePixel = true, useStrip = false, useClusterCleaning, useTruncated = false,
+                                mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, 0, useTemplateLayer_, skipPixelL1 = false, skip_templates_ias = 2,
+                             false, false, true, pixelCPE_, tTopo, track->px(), track->py(), track->pz(), track->charge());
 
                 dedxIas_PixelOnly = dedxIas_PixelOnly_Tmp.numberOfMeasurements() > 0 ? &dedxIas_PixelOnly_Tmp : nullptr;
 
                 //globalIas_ Strip only
                 dedxIas_StripOnly_Tmp =
-                    computedEdx(track->eta(),run_number, year, dedxHits, dEdxSF, localdEdxTemplates = dEdxTemplatesPU[i], usePixel = false, useStrip = true, useClusterCleaning, useTruncated = false,
-                                mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, 0, useTemplateLayer_, skipPixelL1 = false, skip_templates_ias = 0);
+                    computedEdx(track->eta(), iSetup, run_number, year, dedxHits, dEdxSF, localdEdxTemplates = dEdxTemplatesPU[i], usePixel = false, useStrip = true, useClusterCleaning, useTruncated = false,
+                                mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, 0, useTemplateLayer_, skipPixelL1 = false, skip_templates_ias = 0,
+                             false, false, true, pixelCPE_, tTopo, track->px(), track->py(), track->pz(), track->charge());
 
                 dedxIas_StripOnly = dedxIas_StripOnly_Tmp.numberOfMeasurements() > 0 ? &dedxIas_StripOnly_Tmp : nullptr;
 
                 //globalIas_ Pixel only no BPIXL1
                 dedxIas_PixelOnly_noL1_Tmp =
-                    computedEdx(track->eta(),run_number, year, dedxHits, dEdxSF, localdEdxTemplates = dEdxTemplatesPU[i], usePixel = true, useStrip = false, useClusterCleaning, useTruncated = false,
-                                mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, 0, useTemplateLayer_, skipPixelL1 = true, skip_templates_ias = 2);
+                    computedEdx(track->eta(), iSetup, run_number, year, dedxHits, dEdxSF, localdEdxTemplates = dEdxTemplatesPU[i], usePixel = true, useStrip = false, useClusterCleaning, useTruncated = false,
+                                mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, 0, useTemplateLayer_, skipPixelL1 = true, skip_templates_ias = 2,
+                             false, false, true, pixelCPE_, tTopo, track->px(), track->py(), track->pz(), track->charge());
 
                 dedxIas_PixelOnly_noL1 = dedxIas_PixelOnly_noL1_Tmp.numberOfMeasurements() > 0 ? &dedxIas_PixelOnly_noL1_Tmp : nullptr;
 
                 //symmetric Smirnov discriminator - Is
                 dedxIs_StripOnly_Tmp =
-                computedEdx(track->eta(),run_number, year, dedxHits, dEdxSF, localdEdxTemplates = dEdxTemplatesPU[i], usePixel = true, useStrip = false, useClusterCleaning, useTruncated = false,
-                            mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, 0, useTemplateLayer_, skipPixelL1 = true, skip_templates_ias = 2, symmetricSmirnov = true);
+                computedEdx(track->eta(), iSetup, run_number, year, dedxHits, dEdxSF, localdEdxTemplates = dEdxTemplatesPU[i], usePixel = true, useStrip = false, useClusterCleaning, useTruncated = false,
+                            mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, 0, useTemplateLayer_, skipPixelL1 = true, skip_templates_ias = 2, symmetricSmirnov = true,
+                             false, true,  pixelCPE_, tTopo, track->px(), track->py(), track->pz(), track->charge());
 
                 dedxIs_StripOnly = dedxIs_StripOnly_Tmp.numberOfMeasurements() > 0 ? &dedxIs_StripOnly_Tmp : nullptr;
               
                 // the FiStrips variable
                 dedxMorrisMethod_StripOnly_Tmp =
-                computedEdx(track->eta(),run_number, year, dedxHits, dEdxSF, localdEdxTemplates = dEdxTemplatesPU[i], usePixel = false, useStrip = true, useClusterCleaning, useTruncated = false,
-                            mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, 0, useTemplateLayer_, skipPixelL1 = false, skip_templates_ias = 0, symmetricSmirnov = false, useMorrisMethod = true);
+                computedEdx(track->eta(), iSetup, run_number, year, dedxHits, dEdxSF, localdEdxTemplates = dEdxTemplatesPU[i], usePixel = false, useStrip = true, useClusterCleaning, useTruncated = false,
+                            mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, 0, useTemplateLayer_, skipPixelL1 = false, skip_templates_ias = 0, symmetricSmirnov = false, useMorrisMethod = true,
+ true, pixelCPE_, tTopo, track->px(), track->py(), track->pz(), track->charge());
                 
                 dedxMorrisMethod_StripOnly = dedxMorrisMethod_StripOnly_Tmp.numberOfMeasurements() > 0 ? &dedxMorrisMethod_StripOnly_Tmp : nullptr;
 
@@ -3278,14 +3307,25 @@ for ( int q=0; q<MAX_MuonHLTFilters;q++) {
       }
     }
 
+    //check impact of no pixel cleaning 
+    auto dedxIh_test_tmp3 =
+    computedEdx(track->eta(), iSetup, run_number, year, dedxHits, dEdxSF, localdEdxTemplates = nullptr, usePixel = true, useStrip = true, useClusterCleaning, useTruncated = false,
+                    mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, &dEdxErr, useTemplateLayer_, skipPixelL1 = true,
+                    0, false, false, false, pixelCPE_, tTopo, track->px(), track->py(), track->pz(), track->charge());
+    reco::DeDxData* dedxtest_nopixcl = dedxIh_test_tmp3.numberOfMeasurements() > 0 ? &dedxIh_test_tmp3 : nullptr;
+
     // Preselection cuts for a CR where the pT cut is flipped
     bool passedCutsArrayForCR[15];
     std::copy(std::begin(passedCutsArray), std::end(passedCutsArray), std::begin(passedCutsArrayForCR));
     passedCutsArrayForCR[1] = (track->pt() > 50 && track->pt() < 55) ? true : false;
+
     
     if (debug_ > 2 && trigInfo_ > 0) LogPrint(MOD) << "\n      >> Check if we pass Preselection for CR";
     if (passPreselection(passedCutsArrayForCR, false) && doPostPreSplots_) {
       tuple->PostPreS_Ias_CR->Fill(globalIas_, EventWeight_);
+      tuple->PostPreS_Ih_CR->Fill(globalIh_, EventWeight_);
+      tuple->PostPreS_Ihstrip_CR->Fill((dedxIh_StripOnly ? dedxIh_StripOnly->dEdx() : -1) , EventWeight_);
+      tuple->PostPreS_Ih_nopixcl_CR->Fill((dedxtest_nopixcl ? dedxtest_nopixcl->dEdx() : -1) , EventWeight_);
       tuple->PostPreS_Pt_lowPt_CR->Fill(track->pt(), EventWeight_);
       tuple->PostPreS_ProbQNoL1_CR->Fill(1 - probQonTrackNoL1, EventWeight_);
       tuple->PostPreS_ProbQNoL1VsIas_CR->Fill(1 - probQonTrackNoL1, globalIas_, EventWeight_);
@@ -3308,8 +3348,29 @@ for ( int q=0; q<MAX_MuonHLTFilters;q++) {
     // PAY ATTENTION : PU == NPV for the following loop !
     if (passPreselection(passedCutsArrayForGiTemplates, false)) {
       if (doPostPreSplots_) {
+        //check impact of no clustercleaning (in strip and in pix)
+        auto dedxIh_test_tmp =
+        computedEdx(track->eta(), iSetup, run_number, year, dedxHits, dEdxSF, localdEdxTemplates = nullptr, usePixel = true, useStrip = true, false, useTruncated = false,
+                    mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, &dEdxErr, useTemplateLayer_, skipPixelL1 = true,
+                    0, false, false, false,  pixelCPE_, tTopo, track->px(), track->py(), track->pz(), track->charge());
+        reco::DeDxData* dedxtest_noclean = dedxIh_test_tmp.numberOfMeasurements() > 0 ? &dedxIh_test_tmp : nullptr;
+        //check impact of no clustercleaning and no condition of the cluster to be inside the module
+        auto dedxIh_test_tmp2 =
+        computedEdx(track->eta(), iSetup, run_number, year, dedxHits, dEdxSF, localdEdxTemplates = nullptr, usePixel = true, useStrip = true, false, useTruncated = false,
+                    false, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, &dEdxErr, useTemplateLayer_, skipPixelL1 = true,
+                    0, false, false, false, pixelCPE_, tTopo, track->px(), track->py(), track->pz(), track->charge());
+        reco::DeDxData* dedxtest_noinside = dedxIh_test_tmp2.numberOfMeasurements() > 0 ? &dedxIh_test_tmp2 : nullptr;
+
+
+        tuple->PostPreS_Ih_CR_veryLowPt->Fill(globalIh_,preScaleForDeDx*EventWeight_);
+        tuple->PostPreS_Ihstrip_CR_veryLowPt->Fill((dedxIh_StripOnly ? dedxIh_StripOnly->dEdx() : -1) ,preScaleForDeDx*EventWeight_);
+        tuple->PostPreS_Ih_nopixcl_CR_veryLowPt->Fill((dedxtest_nopixcl ? dedxtest_nopixcl->dEdx() : -1) ,preScaleForDeDx*EventWeight_);
+        tuple->PostPreS_Ih_noclean_CR_veryLowPt->Fill((dedxtest_noclean ? dedxtest_noclean->dEdx() : -1) ,preScaleForDeDx*EventWeight_);
+        tuple->PostPreS_Ih_noinside_CR_veryLowPt->Fill((dedxtest_noinside ? dedxtest_noinside->dEdx() : -1) ,preScaleForDeDx*EventWeight_);
         tuple->PostPreS_Ias_CR_veryLowPt->Fill(globalIas_,preScaleForDeDx*EventWeight_);
         tuple->PostPreS_P_CR_veryLowPt->Fill(track->p(),preScaleForDeDx*EventWeight_);
+        tuple->PostPreS_Pt_CR_veryLowPt->Fill(track->pt(),preScaleForDeDx*EventWeight_);
+        tuple->PostPreS_ProbQNoL1_CR_veryLowPt->Fill(1 - probQonTrackNoL1, EventWeight_);
       }
       for(unsigned int h=0; h< dedxHits->size(); h++) {
         DetId detid(dedxHits->detId(h));
@@ -3326,7 +3387,37 @@ for ( int q=0; q<MAX_MuonHLTFilters;q++) {
         }
         pathlenghtForIndxH = dedxHits->pathlength(h) * 10;
         chargeForIndxH = dedxHits->charge(h);
-        if (createGiTemplates_) {
+
+        bool cleaning = true;
+        bool dedx_inside = true;
+        if (detid.subdetId() < 3) {
+              // Pixel corrections
+              float pixelScaling = GetSFPixel(detid.subdetId(), detid, year, run_number);
+              chargeForIndxH *= pixelScaling;
+        }
+        else {
+              // saturation correction of the charge
+              const SiStripCluster* cluster = dedxHits->stripCluster(h);
+              std::vector<int> amplitudes = convert(cluster->amplitudes());
+              amplitudes = SaturationCorrection(amplitudes,0.10,0.04,true,20,25);
+              float dedx_charge = 0;
+              for (unsigned int s = 0; s < amplitudes.size(); s++) {
+                 dedx_charge+=amplitudes[s];
+              }
+              chargeForIndxH = dedx_charge;
+
+              // cleaning cuts
+              std::vector<int> amplitudes2 = convert(cluster->amplitudes());
+              std::vector<int> amplitudesPrim = CrossTalkInv(amplitudes2, 0.10, 0.04, true);
+              cleaning = clusterCleaning(amplitudesPrim, 1);
+              dedx_inside = isHitInsideTkModule(dedxHits->pos(h), dedxHits->detId(h), cluster);
+        }
+
+
+
+        if (cleaning && dedx_inside)  {
+        //
+         if (createGiTemplates_) {
            int npv = vertexColl.size();
            for (int i = 0 ; i < NbPuBins_ ; i++){
              if (npv > PuBins_[i] && npv <= PuBins_[i+1]) {
@@ -3356,6 +3447,29 @@ for ( int q=0; q<MAX_MuonHLTFilters;q++) {
             tuple->Calibration_GiTemplate->Fill(modulgeomForIndxH, pathlenghtForIndxH, scaleFactor*chargeForIndxH/(pathlenghtForIndxH*normMult), preScaleForDeDx);
           }
         }//end condition createGitemplates
+
+        // ADD plots to answer Slava's questions about Charge Resolution
+        if (doPostPreSplots_) {
+             int layer_num = 0;
+             float scaleF = (detid.subdetId() < 3) ? dEdxSF_0_*dEdxSF_1_ : dEdxSF_0_;
+             float factorChargeToE = (detid.subdetId() < 3) ? 3.61e-06 : 3.61e-06 * 265;
+             float pathL = dedxHits->pathlength(h);
+//             cout << " test  ScaleF " << detid.subdetId() << " scaleF " << scaleF << endl;
+             if (detid.subdetId() < 3) {
+                if (detid.subdetId() == PixelSubdetector::PixelBarrel) layer_num=tTopo->pxbLayer(detid);
+                else layer_num=tTopo->pxfDisk(detid)+4;
+                tuple->PostPreS_CpPL_pix_CR_veryLowPt->Fill(scaleF*chargeForIndxH*factorChargeToE/pathL, layer_num, EventWeight_);
+             }
+             else {
+               if (detid.subdetId() == StripSubdetector::TIB) layer_num = abs(int(tTopo->tibLayer(detid)));
+               if (detid.subdetId() == StripSubdetector::TOB) layer_num = abs(int(tTopo->tobLayer(detid))) + 4;
+               if (detid.subdetId() == StripSubdetector::TID) layer_num = abs(int(tTopo->tidWheel(detid))) + 10;
+               if (detid.subdetId() == StripSubdetector::TEC) layer_num = abs(int(tTopo->tecWheel(detid))) + 13;
+               tuple->PostPreS_CpPL_strip_CR_veryLowPt->Fill(scaleF*chargeForIndxH*factorChargeToE/pathL, layer_num, EventWeight_);
+             }
+        }
+       } // end if on the cleaning and the inside 
+
       } // end loop on dEdx hits
     } // end condition on passing preselection cuts for the Gi templates
 
@@ -3881,6 +3995,14 @@ for ( int q=0; q<MAX_MuonHLTFilters;q++) {
           tuple->Stab_invB_DT_VsRun->Fill(CurrentRun_, dttof->inverseBeta(), EventWeight_);
           tuple->Stab_invB_CSC_VsRun->Fill(CurrentRun_, csctof->inverseBeta(), EventWeight_);
         }
+
+        int nsat_highp = (dedxMObj) ?  dedxMObj->numberOfSaturatedMeasurements() : 0.0;
+        int nsize_highp = (dedxMObj) ?  dedxMObj->numberOfMeasurements() : 0.0;
+        float fracsat_highp = 0;
+        if (nsize_highp) fracsat_highp = nsat_highp*1./(nsize_highp*1.);
+        if (nsat_highp>10) nsat_highp=10;
+        tuple->Sat_nsat->Fill(nsat_highp, EventWeight_);
+        tuple->Sat_fracsat->Fill(fracsat_highp,EventWeight_);
 
       }
 
@@ -5183,15 +5305,17 @@ for ( int q=0; q<MAX_MuonHLTFilters;q++) {
 
       // Ih no pixel L1
       auto dedxIh_noL1_Tmp =
-        computedEdx(generalTrack->eta(),run_number, year, dedxHits, dEdxSF, localdEdxTemplates = nullptr, usePixel = true, useStrip = true, useClusterCleaning, useTruncated = false,
-                    mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, &dEdxErr, useTemplateLayer_, skipPixelL1 = true);
+        computedEdx(generalTrack->eta(), iSetup,  run_number, year, dedxHits, dEdxSF, localdEdxTemplates = nullptr, usePixel = true, useStrip = true, useClusterCleaning, useTruncated = false,
+                    mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, &dEdxErr, useTemplateLayer_, skipPixelL1 = true,
+                    0, false, false, true, pixelCPE_, tTopo, generalTrack->px(), generalTrack->py(), generalTrack->pz(), generalTrack->charge());
 
       reco::DeDxData* dedxIh_noL1 = dedxIh_noL1_Tmp.numberOfMeasurements() > 0 ? &dedxIh_noL1_Tmp : nullptr;
 
       // Ih Strip only
       auto dedxIh_StripOnly_Tmp =
-        computedEdx(generalTrack->eta(),run_number, year, dedxHits, dEdxSF, localdEdxTemplates = nullptr, usePixel = false, useStrip = true, useClusterCleaning, useTruncated = false,
-                    mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, &dEdxErr, useTemplateLayer_);
+        computedEdx(generalTrack->eta(),iSetup, run_number, year, dedxHits, dEdxSF, localdEdxTemplates = nullptr, usePixel = false, useStrip = true, useClusterCleaning, useTruncated = false,
+                    mustBeInside, MaxStripNOM, correctFEDSat, crossTalkInvAlgo = 1, dropLowerDeDxValue = 0.0, &dEdxErr, useTemplateLayer_,
+                    false, 0, false, false, true, pixelCPE_, tTopo, generalTrack->px(), generalTrack->py(), generalTrack->pz(), generalTrack->charge());
 
       reco::DeDxData* dedxIh_StripOnly = dedxIh_StripOnly_Tmp.numberOfMeasurements() > 0 ? &dedxIh_StripOnly_Tmp : nullptr;
 
@@ -5358,6 +5482,15 @@ for ( int q=0; q<MAX_MuonHLTFilters;q++) {
         tuple->K_and_C_Ih_strip_VsP_1->Fill(generalTrack->p(),ih0_strip, preScaleForDeDx*EventWeight_);
         tuple->K_and_C_Ih_strip_VsP_2->Fill(generalTrack->p(),ih0_strip, preScaleForDeDx*EventWeight_);
 
+
+        int nsat_lowp = (dedxIh_noL1) ?  dedxIh_noL1->numberOfSaturatedMeasurements() : 0.0;
+        int nsize_lowp = (dedxIh_noL1) ?  dedxIh_noL1->numberOfMeasurements() : 0.0;
+        float fracsat_lowp = 0;
+        if (nsize_lowp) fracsat_lowp = nsat_lowp*1./(nsize_lowp*1.);
+        if (nsat_lowp>10) nsat_lowp=10;
+        tuple->K_and_C_nsat->Fill(nsat_lowp, preScaleForDeDx*EventWeight_);
+        tuple->K_and_C_fracsat->Fill(fracsat_lowp,preScaleForDeDx*EventWeight_);
+
         // some kinematical plots
         float tk_Mass =  GetMass(generalTrack->p(), ih0_noL1, dEdxK_, dEdxC_);
         if (ih0_noL1> 5.5 && generalTrack->p()<5) {
@@ -5388,6 +5521,7 @@ for ( int q=0; q<MAX_MuonHLTFilters;q++) {
                  dedx_charge+=amplitudes[s];
               }
               float charge_over_pathlength = dedx_charge * scaleFactor * factorChargeToE / dedx_pathlength;
+              float charge_over_path_nosf = dedx_charge * factorChargeToE / dedx_pathlength;
 
               // cleaning cuts
               std::vector<int> amplitudes2 = convert(cluster->amplitudes());
@@ -5398,8 +5532,10 @@ for ( int q=0; q<MAX_MuonHLTFilters;q++) {
               if (cleaning && dedx_inside)  {
                  if (fabs(generalTrack->eta()<0.4)){
                    tuple->SF_HHit2DStrip_loose->Fill(generalTrack->p(), charge_over_pathlength, preScaleForDeDx*EventWeight_);
-                   if ( fabs(dzForCalib) < globalMaxDZ_ && fabs(dxyForCalib) < globalMaxDXY_)
+                   if ( fabs(dzForCalib) < globalMaxDZ_ && fabs(dxyForCalib) < globalMaxDXY_) {
                      tuple->SF_HHit2DStrip->Fill(generalTrack->p(), charge_over_pathlength, preScaleForDeDx*EventWeight_);
+                     tuple->SF_HHit2DStrip_nosf->Fill(generalTrack->p(), charge_over_path_nosf, preScaleForDeDx*EventWeight_);
+                   }
                  }
               }
            }
@@ -5410,14 +5546,17 @@ for ( int q=0; q<MAX_MuonHLTFilters;q++) {
               float pixelScaling = GetSFPixel(detid.subdetId(), detid, year, run_number);
               scaleFactor *= pixelScaling;
               float charge_over_pathlength = dedx_charge * scaleFactor * factorChargeToE / dedx_pathlength;
+              float charge_over_path_nosf = dedx_charge * factorChargeToE / dedx_pathlength;
               // BPIXL1
               bool isBPIXL1=false;
               if (detid.subdetId() == 1 && ((detid >> 20) & 0xF) == 1) isBPIXL1=true;
               if (!isBPIXL1) {
                  if (fabs(generalTrack->eta()<0.4)){
                    tuple->SF_HHit2DPix_loose->Fill(generalTrack->p(), charge_over_pathlength, preScaleForDeDx*EventWeight_);
-                   if ( fabs(dzForCalib) < globalMaxDZ_ && fabs(dxyForCalib) < globalMaxDXY_)
+                   if ( fabs(dzForCalib) < globalMaxDZ_ && fabs(dxyForCalib) < globalMaxDXY_) {
                       tuple->SF_HHit2DPix->Fill(generalTrack->p(), charge_over_pathlength, preScaleForDeDx*EventWeight_);
+                      tuple->SF_HHit2DPix_nosf->Fill(generalTrack->p(), charge_over_path_nosf, preScaleForDeDx*EventWeight_);
+                   }
                  }
               }
            }

--- a/Analyzer/plugins/Analyzer.h
+++ b/Analyzer/plugins/Analyzer.h
@@ -107,14 +107,6 @@
 
 // ~~~~~~~~~ user include files ~~~~~~~~~
 #define FWCORE
-#include "SUSYBSMAnalysis/Analyzer/interface/CommonFunction.h"
-#include "SUSYBSMAnalysis/Analyzer/interface/DeDxUtility.h"
-#include "SUSYBSMAnalysis/Analyzer/interface/TOFUtility.h"
-#include "SUSYBSMAnalysis/Analyzer/interface/TupleMaker.h"
-#include "SUSYBSMAnalysis/Analyzer/interface/SaturationCorrection.h"
-#include "SUSYBSMAnalysis/Analyzer/interface/MCWeight.h"
-#include "SUSYBSMAnalysis/Analyzer/interface/Regions.h"
-#include "SUSYBSMAnalysis/Analyzer/interface/TrigToolsFuncs.h"
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "RecoLocalTracker/Records/interface/TkPixelCPERecord.h"
@@ -127,6 +119,14 @@
 
 #include "DataFormats/ParticleFlowReco/interface/PFDisplacedVertex.h"
 
+#include "SUSYBSMAnalysis/Analyzer/interface/CommonFunction.h"
+#include "SUSYBSMAnalysis/Analyzer/interface/DeDxUtility.h"
+#include "SUSYBSMAnalysis/Analyzer/interface/TOFUtility.h"
+#include "SUSYBSMAnalysis/Analyzer/interface/TupleMaker.h"
+#include "SUSYBSMAnalysis/Analyzer/interface/SaturationCorrection.h"
+#include "SUSYBSMAnalysis/Analyzer/interface/MCWeight.h"
+#include "SUSYBSMAnalysis/Analyzer/interface/Regions.h"
+#include "SUSYBSMAnalysis/Analyzer/interface/TrigToolsFuncs.h"
 
 
 using namespace std;

--- a/Analyzer/test/CalibMacros/FitKandC.C
+++ b/Analyzer/test/CalibMacros/FitKandC.C
@@ -1,0 +1,1270 @@
+#include <exception>
+#include <vector>
+#include <fstream>
+
+#include "TROOT.h"
+#include "TFile.h"
+#include "TDirectory.h"
+#include "TChain.h"
+#include "TObject.h"
+#include "TCanvas.h"
+#include "TMath.h"
+#include "TLegend.h"
+#include "TGraph.h"
+#include "TH1.h"
+#include "TH2.h"
+#include "TH3.h"
+#include "TTree.h"
+#include "TF1.h"
+#include "TGraphAsymmErrors.h"
+#include "TGraphErrors.h"
+#include "TPaveText.h"
+#include "TProfile.h"
+#include "TProfile2D.h"
+#include "TCutG.h"
+//#include "../../AnalysisCode/tdrstyle.C"
+//#include "../../AnalysisCode/Analysis_PlotFunction.h"
+
+// inspiré de https://github.com/CMS-HSCP/SUSYBSMAnalysis-HSCP/blob/Run2_2016/test/UsefulScripts/DeDxStudy/MakePlot.C
+
+
+using namespace std;
+
+void ExtractConstants(TH2D* input1, TH2D* input2, double* K, double* C, double* Kerr, double* Cerr, double MinRange = 1.0, double MaxRange = 1.6, double MassCenter = 1.875, double LeftMassMargin = 0.2, double RightMassMargin = 0.8, double yPionMax=4.2); // by default use protons
+double GetMass(double P, double I, double* K, double* C);
+void SaveCanvas(TCanvas* c, std::string path, std::string name, bool OnlyPPNG=false);
+TF1* GetMassLine(double M, double K, double C, bool left=false);
+void ExtracttheCConstants(TH2D* inputlong, double* C,  double* Cerr) ;
+void FitCalone(TString filename);
+void FitKandC_sig();
+void ExtractConstants_sig(TH2D* input, double* K, double* C, double* Kerr, double* Cerr, double MinRange = 1.0, double MaxRange = 1.6, double MassCenter = 1.875); // by default use protons
+void ExtractProj(TH2D* inputlong, TH2D* inputshort,double* K, double* C, 
+      double MinRange, double MaxRange, double MassCenter, double LeftMassMargin, double RightMassMargin, double yPionMax,
+      TH1D* FitResultpion,  TH1D* FitResult);
+void compaFits(TString filename1, TString filename2, double Kval, double Cval);
+void TestExtractConstants(TH2D* input1, TH2D* input2, double* K, double* C, double* N, double* Kerr, double* Cerr, double* Nerr, double MinRange = 1.0, double MaxRange = 1.6, double MassCenter = 1.875, double LeftMassMargin = 0.2, double RightMassMargin = 0.8, double yPionMax=4.2); // by default use protons
+TF1* TestGetMassLine(double M, double K, double C, double N, bool left=false);
+Double_t TestfitSpecial(Double_t *x, Double_t *par);
+Double_t TestfitSpecial2(Double_t *x, Double_t *par);
+
+void FitKandC(TString filename){
+   double K_ = 3.0; double Kerr_ = 0.001; double C_ = 3.; double Cerr_ = 0.001;
+   double Ktmp = K_ ; double Ctmp = C_; double KerrTmp = Kerr_; double CerrTmp = Cerr_;
+   bool uncorr = true;
+   TFile* myfile;
+   myfile = new TFile (filename);
+
+   TH2D* HdedxVsP_1fit;
+   TH2D* HdedxVsP_2fit;
+   bool pixelOnly = false;
+//   myfile->cd();
+
+//    // Ih no drop, no L1
+// ---->>  THE HISTO (original name in ntuple : dEdX0noL1VsP_lowp)
+
+
+   myfile->GetObject("HSCParticleAnalyzer/BaseName/K_and_C_Ih_noL1_VsP_1",HdedxVsP_1fit);
+   myfile->GetObject("HSCParticleAnalyzer/BaseName/K_and_C_Ih_noL1_VsP_1",HdedxVsP_2fit);
+//
+/*
+   myfile->GetObject("HSCParticleAnalyzer/BaseName/K_and_C_Ih_noL1_VsP_loose1",HdedxVsP_1fit);
+   myfile->GetObject("HSCParticleAnalyzer/BaseName/K_and_C_Ih_noL1_VsP_loose1",HdedxVsP_2fit);
+*/
+
+  // Ih strip only
+  /*
+   myfile->GetObject("HSCParticleAnalyzer/BaseName/K_and_C_Ih_strip_VsP_1",HdedxVsP_1fit);
+   myfile->GetObject("HSCParticleAnalyzer/BaseName/K_and_C_Ih_strip_VsP_1",HdedxVsP_2fit);
+  */
+
+//     if (!pixelOnly) ExtractConstants (HdedxVsP_2fit, HdedxVsP_1fit, &Ktmp, &Ctmp, &KerrTmp, &CerrTmp, 0.5, 1.5, 0.938, 0.2, 0.5, 4.2);
+     if (!pixelOnly) ExtractConstants (HdedxVsP_2fit, HdedxVsP_1fit, &Ktmp, &Ctmp, &KerrTmp, &CerrTmp, 0.5, 1.2, 0.938, 0.2, 0.5, 4.2);
+//     if (!pixelOnly) ExtractConstants (HdedxVsP_2fit, HdedxVsP_1fit, &Ktmp, &Ctmp, &KerrTmp, &CerrTmp, 0.5, 1., 0.938, 0.2, 0.5, 4.2);
+  // for Pixel only 
+     else ExtractConstants (HdedxVsP_2fit, HdedxVsP_1fit, &Ktmp, &Ctmp, &KerrTmp, &CerrTmp, 0.6, 1., 0.938, 0.1, 0.8, 4.2);
+
+   TCanvas* c2 = new TCanvas("c2", "c2", 800,600);
+   c2->cd();
+   TF1* PionLine = GetMassLine(0.140, Ktmp, Ctmp, false);
+   PionLine->SetLineColor(1);
+   PionLine->SetLineWidth(2);
+   TF1* KaonLine = GetMassLine(0.494, Ktmp, Ctmp, false);
+   KaonLine->SetLineColor(1);
+   KaonLine->SetLineWidth(2);
+   TF1* ProtonLine = GetMassLine(0.938,Ktmp, Ctmp, false);
+   ProtonLine->SetLineColor(1);
+   ProtonLine->SetLineWidth(2);
+
+   TF1* DeuteronLine = GetMassLine(1.8756,Ktmp, Ctmp, false);
+   DeuteronLine->SetLineColor(1);
+   DeuteronLine->SetLineWidth(2);
+
+
+
+   TLine* linepion = new TLine(2.,Ctmp,5., Ctmp);
+   linepion->SetLineColor(1);
+   linepion->SetLineWidth(2);
+
+//   HdedxVsP_2fit->Rebin2D(5,10);
+   HdedxVsP_1fit->SetTitle("");
+   HdedxVsP_1fit->GetXaxis()->SetTitle("p");
+   HdedxVsP_1fit->GetYaxis()->SetTitle("Ih");
+   HdedxVsP_1fit->Draw("colz");
+   PionLine->Draw("same");
+   KaonLine->Draw("same");
+   ProtonLine->Draw("same");
+   DeuteronLine->Draw("same");
+   linepion->Draw("same");
+   SaveCanvas(c2, "dirtest/", "dedxVsP_lines");
+   
+
+  TCanvas* c3 = new TCanvas("c3", "c3", 800,600);
+   c3->cd();
+   HdedxVsP_2fit->Draw("colz");
+   PionLine->Draw("same");
+   KaonLine->Draw("same");
+   ProtonLine->Draw("same");
+   linepion->Draw("same");
+   SaveCanvas(c3, "dirtest/", "dedxVsP_long");
+   
+  gStyle->SetOptStat(0);
+  c2->cd();
+  c2->SetLogz(1);
+  SaveCanvas(c2, "dirtest/", "dedxVsP_lines_logZ"); 
+   c3->cd();
+  c3->SetLogz(1);
+   SaveCanvas(c3, "dirtest/", "dedxVsP_long_logZ");
+
+   
+
+}
+void FitKandC_sig(){
+   double K_ = 1.6; double Kerr_ = 0.001; double C_ = 4.3; double Cerr_ = 0.001;
+   double Ktmp = K_ ; double Ctmp = C_; double KerrTmp = Kerr_; double CerrTmp = Cerr_;
+   TFile* myfile;
+        myfile = new TFile ("testMass2400.root");
+        cout << " opening testMass2400.root" << endl;
+
+   TH2D* HdedxVsP_2fit;
+   myfile->cd();
+   HdedxVsP_2fit = (TH2D*)gROOT->FindObject("dEdXVsP");
+   ExtractConstants_sig (HdedxVsP_2fit, &Ktmp, &Ctmp, &KerrTmp, &CerrTmp, 500., 3000., 2400);
+
+   TCanvas* c2 = new TCanvas("c2", "c2", 800,600);
+   c2->cd();
+   TF1* SigLine = GetMassLine(2.4, Ktmp, Ctmp, false);
+   SigLine->SetLineColor(1);
+   SigLine->SetLineWidth(2);
+
+   HdedxVsP_2fit->Draw("colz");
+   SigLine->Draw("same");
+   SaveCanvas(c2, "dirtest/", "SigdedxVsP_lines");
+   
+
+
+   
+
+}
+void FitCalone(TString filename){
+   double C_ = 3.; double Cerr_ = 0.001;
+   double Ctmp = C_;  double CerrTmp = Cerr_;
+   TFile* myfile;
+   myfile = new TFile (filename);
+
+   TH2D* HdedxVsP_2fit;
+   myfile->cd();
+   HdedxVsP_2fit = (TH2D*)gROOT->FindObject("dEdX0noL1VsP_lowp2");
+   HdedxVsP_2fit->Rebin2D(2,1);
+
+   ExtracttheCConstants (HdedxVsP_2fit, &Ctmp, &CerrTmp);
+
+
+   TCanvas* c2 = new TCanvas("c2", "c2", 800,600);
+   c2->cd();
+
+   TLine* linepion = new TLine(2.,Ctmp,25., Ctmp);
+   linepion->SetLineColor(1);
+   linepion->SetLineWidth(2);
+
+   HdedxVsP_2fit->Draw("colz");
+   linepion->Draw("same");
+   SaveCanvas(c2, "dirtest/", "test_LineC");
+
+}
+
+
+void ExtractConstants(TH2D* inputlong, TH2D* inputshort,double* K, double* C, double* Kerr, double* Cerr,
+      double MinRange, double MaxRange, double MassCenter, double LeftMassMargin, double RightMassMargin, double yPionMax)
+{
+       char buffer[2048];
+       bool hasConverged = false;
+
+//       for(unsigned int loop=0;loop<5 and !hasConverged; loop++){
+//       for(unsigned int loop=0;loop<8 and !hasConverged; loop++){
+       for(unsigned int loop=0;loop<20 and !hasConverged; loop++){
+	      TH2D* inputnew = (TH2D*)inputshort->Clone("tempTH2D");
+	      TH2D* inputnewPion = (TH2D*)inputlong->Clone("tempTH2D2");
+//	      inputnew->Rebin2D(5,10);
+	      for(int x=0;x<=inputnew->GetNbinsX()+1;x++){
+	      for(int y=0;y<=inputnew->GetNbinsY()+1;y++){
+		double Mass = GetMass(inputnew->GetXaxis()->GetBinCenter(x),inputnew->GetYaxis()->GetBinCenter(y), K, C);
+		if(isnan (float(Mass)) || Mass<MassCenter-(LeftMassMargin) || Mass>MassCenter+RightMassMargin){
+		  inputnew->SetBinContent(x,y,0);        
+		  inputnew->SetBinError(x,y,0);        
+		  //cout<<x<<"   "<<y<<endl;
+		}
+	      }}
+	      for(int x=0;x<=inputnewPion->GetNbinsX()+1;x++){
+   	        for(int y=0;y<=inputnewPion->GetNbinsY()+1;y++){
+//                    if (inputnewPion->GetXaxis()->GetBinCenter(x)<10) inputnewPion->SetBinContent(x,y,0);
+                    if (inputnewPion->GetXaxis()->GetBinCenter(x)<2.5) {
+                          inputnewPion->SetBinContent(x,y,0);
+                          inputnewPion->SetBinError(x,y,0);
+                    }
+//                    if (inputnewPion->GetXaxis()->GetBinCenter(x)>10) inputnewPion->SetBinContent(x,y,0);
+	  	    if (inputnewPion->GetYaxis()->GetBinCenter(y)<2 || inputnewPion->GetYaxis()->GetBinCenter(y)>yPionMax) {
+                          inputnewPion->SetBinContent(x,y,0);
+                          inputnewPion->SetBinError(x,y,0);
+                    }
+	      }}
+//	      inputnewPion->Rebin2D(10,10);
+
+	      
+
+	      TCanvas* c1 = new TCanvas("c1", "c1", 800,600);
+	      c1->SetLogz(true);
+	      inputnew->SetStats(kFALSE);
+	      inputnew->GetXaxis()->SetTitle("track momentum (GeV)");
+	      inputnew->GetYaxis()->SetTitle("dE/dx (MeV/cm)");
+	      inputnew->SetAxisRange(0,25,"X");
+	      inputnew->SetAxisRange(0,15,"Y");
+	      inputnew->Draw("COLZ");
+
+	//      KaonLine->Draw("same");
+	//      ProtonLine->Draw("same");
+	//      DeuteronLine->Draw("same");
+	//      TritonLine->Draw("same");
+
+	      SaveCanvas(c1, "dirtest/", "dedxVsP");
+
+
+	      inputnewPion->SetStats(kFALSE);
+	      inputnewPion->GetXaxis()->SetTitle("track momentum (GeV)");
+	      inputnewPion->GetYaxis()->SetTitle("dE/dx (MeV/cm)");
+	      inputnewPion->SetAxisRange(0,25,"X");
+	      inputnewPion->SetAxisRange(0,15,"Y");
+              inputnewPion->Draw("COLZ");
+
+	      SaveCanvas(c1, "dirtest/", "dedxVsP_pion");
+
+	      delete c1;
+               TH1D* FitResult = new TH1D("FitResult"       , "FitResult"      ,inputnew->GetXaxis()->GetNbins(),inputnew->GetXaxis()->GetXmin(),inputnew->GetXaxis()->GetXmax());
+	       FitResult->SetTitle("");
+	       FitResult->SetStats(kFALSE);  
+	       FitResult->GetXaxis()->SetTitle("P [GeV]");
+	       FitResult->GetYaxis()->SetTitle("dE/dx Estimator [MeV/cm]");
+	       FitResult->GetYaxis()->SetTitleOffset(1.20);
+	       FitResult->Reset();     
+
+	       TH1D* FitResultPion = new TH1D("FitResultPion", "FitResultPion" ,inputnewPion->GetXaxis()->GetNbins(),inputnewPion->GetXaxis()->GetXmin(),inputnewPion->GetXaxis()->GetXmax());
+               FitResultPion->SetTitle("");
+               FitResultPion->SetStats(kFALSE);
+               FitResultPion->GetXaxis()->SetTitle("P [GeV]");
+               FitResultPion->GetYaxis()->SetTitle("dE/dx Estimator [MeV/cm]");
+               FitResultPion->GetYaxis()->SetTitleOffset(1.20);
+               FitResultPion->Reset();
+
+               for(int x=1;x<inputnewPion->GetNbinsX();x++){
+		  TH1D* ProjectionPion = (TH1D*)(inputnewPion->ProjectionY("proj",x,x))->Clone();
+                  if(ProjectionPion->Integral()<100)continue;
+                  ProjectionPion->SetAxisRange(0.1,25,"X");
+//                  ProjectionPion->Sumw2();
+                  ProjectionPion->Scale(1.0/ProjectionPion->Integral());
+
+                  TF1* mygausPion = new TF1("mygausPion","gaus", 2., 15);
+                  ProjectionPion->Fit("mygausPion","Q0 RME");
+                  FitResultPion->SetBinContent(x, mygausPion->GetParameter(1));
+		  cout<< " mygausPion     " <<x<<"  "<<mygausPion->GetParameter(1)<<endl;
+		  FitResultPion->SetBinError  (x, mygausPion->GetParError (1));
+               }
+
+	       for(int x=1;x<inputnew->GetXaxis()->FindBin(1.5);x++){
+		  double P       = inputnew->GetXaxis()->GetBinCenter(x);
+	    
+		  TH1D* Projection = (TH1D*)(inputnew->ProjectionY("proj",x,x))->Clone();
+		  if(Projection->Integral()<100)continue;
+		  Projection->SetAxisRange(0.1,25,"X");
+//		  Projection->Sumw2();
+		  Projection->Scale(1.0/Projection->Integral());
+
+		  TF1* mygaus = new TF1("mygaus","gaus", 2.5, 15);
+		  Projection->Fit("mygaus","Q0 RME");
+		  double chiFromFit  = (mygaus->GetChisquare())/(mygaus->GetNDF());
+		  FitResult->SetBinContent(x, mygaus->GetParameter(1));
+		  FitResult->SetBinError  (x, mygaus->GetParError (1));
+		  mygaus->SetLineColor(2);
+		  mygaus->SetLineWidth(2);
+		  cout<<x<<"  "<<mygaus->GetParameter(1)<<endl;
+
+		  /*
+		  c1  = new TCanvas("canvas", "canvas", 600,600);
+		  Projection->Draw();
+		  Projection->SetTitle("");
+		  Projection->SetStats(kFALSE);
+		  Projection->GetXaxis()->SetTitle("dE/dx Estimator [MeV/cm]");
+		  Projection->GetYaxis()->SetTitle("#Entries");
+		  Projection->GetYaxis()->SetTitleOffset(1.30);
+		  Projection->SetAxisRange(1E-5,1.0,"Y");
+
+		  mygaus->Draw("same");
+
+		  TPaveText* stt = new TPaveText(0.55,0.82,0.79,0.92, "NDC");
+		  stt->SetFillColor(0);
+		  stt->SetTextAlign(31);
+		  sprintf(buffer,"Proton  #mu:%5.1fMeV/cm",mygaus->GetParameter(1));      stt->AddText(buffer);
+		  sprintf(buffer,"Proton  #sigma:%5.1fMeV/cm",mygaus->GetParameter(2));      stt->AddText(buffer);
+		  stt->Draw("same");
+
+		  //std::cout << "P = " << P << "  --> Proton dE/dx = " << mygaus->GetParameter(1) << endl;
+		  c1->SetLogy(true);
+		  sprintf(buffer,"%sProjectionFit_P%03i_%03i","fit/",(int)(100*FitResult->GetXaxis()->GetBinLowEdge(x)),(int)(100*FitResult->GetXaxis()->GetBinUpEdge(x)) );
+		  if(P>=MinRange && P<=MaxRange){SaveCanvas(c1,"dirtest/",buffer);}
+		  delete c1;
+                  delete stt;
+                  */
+                  delete Projection;
+                  delete mygaus;
+	       }
+
+	       c1  = new TCanvas("canvas", "canvas", 800,600);
+	       FitResult->SetAxisRange(0,25,"X");
+	       FitResult->SetAxisRange(0,15,"Y");
+	       FitResult->Draw("");
+
+	       TLine* line1 = new TLine(MinRange, FitResult->GetMinimum(), MinRange, FitResult->GetMaximum());
+	       line1->SetLineWidth(2);
+	       line1->SetLineStyle(2);
+	       line1->Draw();
+
+	       TLine* line2 = new TLine(MaxRange, FitResult->GetMinimum(), MaxRange, FitResult->GetMaximum());
+	       line2->SetLineWidth(2);
+	       line2->SetLineStyle(2);
+	       line2->Draw();
+
+
+	       double prevConstants [] = {*K, *Kerr, *C, *Cerr};
+
+	       TF1* fitC =  new TF1("fitC","[0]", 1,25);
+	       fitC->SetParName(0,"C");
+	       fitC->SetParameter(0, 3.);
+	       fitC->SetParLimits(0, 2,5);
+	       fitC->SetLineWidth(2);
+               fitC->SetLineColor(2);
+               FitResultPion->Fit("fitC", "M R E I 0");
+//               fitC->SetRange(5.,25);
+               fitC->SetRange(3.,5);
+//               fitC->SetRange(3.5,5);
+               fitC->Draw("same");
+	       *C    = fitC->GetParameter(0);
+	       *Cerr = fitC->GetParError(0);
+	       cout<< "FitResultPion : "<<*C<<"   " <<*Cerr<< endl;
+               
+               c1->SetLogz(1);
+               inputnewPion->Draw("COLZ");
+               FitResultPion->Draw("same");
+               fitC->Draw("same");
+	       sprintf(buffer,"%sFitPion","fit/");
+	       SaveCanvas(c1,"dirtest/",buffer);              
+
+
+
+               char fitfunc[2048];
+//   si on fixe C
+//               *C    = 3.14; 
+               sprintf(fitfunc,"[0]*pow(%6.4f/x,2) +%4.3f",MassCenter, *C);
+               cout << "fitfunc " << fitfunc << endl;
+	       TF1* myfit = new TF1("myfit",fitfunc, MinRange, MaxRange);
+	       // TF1* myfit = new TF1("myfit","[0]*pow(1.8756/x,2) + [1]", MinRange, MaxRange); //1875.6 MeV  deuteron mass
+	       myfit->SetParName  (0,"K");
+	       //myfit->SetParName  (1,"C");
+//	       myfit->SetParameter(0, 1.8);
+	       myfit->SetParameter(0, 2.);
+	       //myfit->SetParameter(1, *C);
+//	       myfit->SetParLimits(0, 1.3,4.0); //
+	       myfit->SetParLimits(0, 1.0,4.0); //
+	       // myfit->SetParLimits(1, 3.8,3.8); // 
+	       myfit->SetLineWidth(2);
+	       myfit->SetLineColor(2);
+	       FitResult->Fit("myfit", "M R E I 0");
+	       myfit->SetRange(MinRange,MaxRange);
+               inputnew->Draw("COLZ");
+               FitResult->Draw("same");
+	       myfit->Draw("same");
+
+	       //double prevConstants [] = {*K, *Kerr, *C, *Cerr};
+	       *K    = myfit->GetParameter(0);
+               //*C    = myfit->GetParameter(1);
+               *Kerr = myfit->GetParError(0);
+               //*Cerr = myfit->GetParError(1);
+	       cout<< "FitResult : "<<*K<<"   " <<*Kerr<< endl;
+	       //cout<< "FitResult : "<<myfit->GetParameter(1)<<"   " <<myfit->GetParError(1)<< endl;
+               printf("K Constant changed from %6.4f+-%6.4f to %6.4f+-%6.4f    (diff = %6.3f%%)\n",
+                prevConstants[0], prevConstants[1], *K, *Kerr, 100.0*((*K)-prevConstants[0])/(*K));
+	       printf("C Constant changed from %6.4f+-%6.4f to %6.4f+-%6.4f    (diff = %6.3f%%)\n",
+                prevConstants[2], prevConstants[3], *C, *Cerr, 100.0*((*C)-prevConstants[2])/(*C));
+
+          if(std::max(fabs(100.0*((*K)-prevConstants[0])/(*K)), fabs(100.0*((*C)-prevConstants[2])/(*C)))<1.0)
+             hasConverged=true;  //<1% variation of the constant --> converged
+
+	       TPaveText* st = new TPaveText(0.40,0.78,0.79,0.89, "NDC");
+	       st->SetFillColor(0);
+	       sprintf(buffer,"K = %4.3f +- %6.4f",myfit->GetParameter(0), myfit->GetParError(0));
+	       st->AddText(buffer);
+	       //sprintf(buffer,"C = %4.3f +- %6.4f",myfit->GetParameter(1), myfit->GetParError(1));
+	       sprintf(buffer,"C = %4.3f +- %6.4f",*C, *Cerr);
+	       st->AddText(buffer);
+	       st->Draw("same");
+	       sprintf(buffer,"%sFit","fit/");
+	       SaveCanvas(c1,"dirtest/",buffer);              
+	       delete c1;
+
+          delete line1;
+          delete line2;
+          delete myfit;
+          delete FitResult;
+          delete inputnew;
+       }
+}
+
+void ExtracttheCConstants(TH2D* inputlong, double* C,  double* Cerr) 
+{
+       char buffer[2048];
+
+	      TH2D* inputnewPion = (TH2D*)inputlong->Clone("tempTH2D2");
+	      for(int x=0;x<=inputnewPion->GetNbinsX()+1;x++){
+   	        for(int y=0;y<=inputnewPion->GetNbinsY()+1;y++){
+                    if (inputnewPion->GetXaxis()->GetBinCenter(x)<10) {
+                       inputnewPion->SetBinContent(x,y,0); 
+                       inputnewPion->SetBinError(x,y,0); 
+                    }
+	  	    if (inputnewPion->GetYaxis()->GetBinCenter(y)<2 || inputnewPion->GetYaxis()->GetBinCenter(y)>4.2) {
+                       inputnewPion->SetBinContent(x,y,0);
+                       inputnewPion->SetBinError(x,y,0);
+                    }
+	      }}
+
+
+	      TCanvas* c1 = new TCanvas("c1", "c1", 800,600);
+	      c1->SetLogz(true);
+
+	      inputnewPion->SetStats(kFALSE);
+	      inputnewPion->GetXaxis()->SetTitle("track momentum (GeV)");
+	      inputnewPion->GetYaxis()->SetTitle("dE/dx (MeV/cm)");
+	      inputnewPion->SetAxisRange(0,25,"X");
+	      inputnewPion->SetAxisRange(0,15,"Y");
+              inputnewPion->Draw("COLZ");
+
+	      SaveCanvas(c1, "dirtest/", "testCalone_region");
+
+
+	      TH1D* ProjectionPion = (TH1D*)inputnewPion->ProjectionY("proj");
+              cout << " mean value " << ProjectionPion->GetMean() << " RMS " << ProjectionPion->GetRMS() << endl;
+              float xminval = ProjectionPion->GetMean() - 0.5;
+              float xmaxval = ProjectionPion->GetMean() + 0.5;
+//              TF1* mygausPion = new TF1("mygausPion","gaus", 2., 5.);
+              TF1* mygausPion = new TF1("mygausPion","gaus", xminval, xmaxval);
+              ProjectionPion->Fit("mygausPion","Q0 RME");
+	      cout<< " mygausPion  mean   " <<mygausPion->GetParameter(1) << "  "<<mygausPion->GetParError(1)<<endl;
+	      cout<< " mygausPion  sigma   " <<mygausPion->GetParameter(2)<<"  "<<mygausPion->GetParError(2)<<endl;
+
+	       *C    = mygausPion->GetParameter(1);
+	       *Cerr = mygausPion->GetParameter(2);
+	       cout<< "FitResultPion : "<<*C<<"   " <<*Cerr<< endl;
+               
+               ProjectionPion->Draw();
+               mygausPion->Draw("same");
+	       sprintf(buffer,"%sFitC_highp","fit/");
+	       SaveCanvas(c1,"dirtest/",buffer);              
+
+}
+
+void ExtractConstants_sig(TH2D* input, double* K, double* C, double* Kerr, double* Cerr,
+      double MinRange, double MaxRange, double MassCenter)
+{
+       char buffer[2048];
+       bool hasConverged = false;
+
+       for(unsigned int loop=0;loop<5 and !hasConverged; loop++){
+	      TH2D* inputnew = (TH2D*)input->Clone("tempTH2D");
+	      for(int x=1;x<=inputnew->GetNbinsX();x++){
+	       for(int y=1;y<=inputnew->GetNbinsY();y++){
+                if (inputnew->GetYaxis()->GetBinCenter(y)<5. && inputnew->GetXaxis()->GetBinCenter(x)<1000) {
+		  inputnew->SetBinContent(x,y,0);        
+		}
+                else if (inputnew->GetYaxis()->GetBinCenter(y)<2.) {
+		  inputnew->SetBinContent(x,y,0);        
+		}
+	       }
+              }  
+
+	      
+
+	      TCanvas* c1 = new TCanvas("c1", "c1", 800,600);
+	      c1->SetLogz(true);
+	      inputnew->SetStats(kFALSE);
+	      inputnew->GetXaxis()->SetTitle("track momentum (GeV)");
+	      inputnew->GetYaxis()->SetTitle("dE/dx (MeV/cm)");
+	      inputnew->Draw("COLZ");
+
+	      SaveCanvas(c1, "dirtest/", "Sig_dedxVsP");
+
+	      delete c1;
+               TH1D* FitResult = new TH1D("FitResult"       , "FitResult"      ,inputnew->GetXaxis()->GetNbins(),inputnew->GetXaxis()->GetXmin(),inputnew->GetXaxis()->GetXmax());
+	       FitResult->SetTitle("");
+	       FitResult->SetStats(kFALSE);  
+	       FitResult->GetXaxis()->SetTitle("P [GeV]");
+	       FitResult->GetYaxis()->SetTitle("dE/dx Estimator [MeV/cm]");
+	       FitResult->GetYaxis()->SetTitleOffset(1.20);
+	       FitResult->Reset();     
+
+	       for(int x=inputnew->GetXaxis()->FindBin(MinRange);x<inputnew->GetXaxis()->FindBin(MaxRange);x++){
+		  double P       = inputnew->GetXaxis()->GetBinCenter(x);
+	    
+		  TH1D* Projection = (TH1D*)(inputnew->ProjectionY("proj",x,x))->Clone();
+		  if(Projection->Integral()<100)continue;
+		  Projection->SetAxisRange(0.1,25,"X");
+		  Projection->Sumw2();
+		  Projection->Scale(1.0/Projection->Integral());
+
+
+		  TF1* mygaus = new TF1("mygaus","gaus", 2.5, 20);
+		  Projection->Fit("mygaus","Q0 RME");
+		  double chiFromFit  = (mygaus->GetChisquare())/(mygaus->GetNDF());
+		  FitResult->SetBinContent(x, mygaus->GetParameter(1));
+		  FitResult->SetBinError  (x, mygaus->GetParError (1));
+		  mygaus->SetLineColor(2);
+		  mygaus->SetLineWidth(2);
+
+		  c1  = new TCanvas("canvas", "canvas", 800,600);
+		  Projection->Draw();
+		  Projection->SetTitle("");
+		  Projection->SetStats(kFALSE);
+		  Projection->GetXaxis()->SetTitle("dE/dx Estimator [MeV/cm]");
+		  Projection->GetYaxis()->SetTitle("#Entries");
+		  Projection->GetYaxis()->SetTitleOffset(1.30);
+		  Projection->SetAxisRange(1E-5,1.0,"Y");
+
+		  mygaus->Draw("same");
+
+
+		  TPaveText* stt = new TPaveText(0.55,0.82,0.79,0.92, "NDC");
+		  stt->SetFillColor(0);
+		  stt->SetTextAlign(31);
+		  sprintf(buffer,"Proton  #mu:%5.1fMeV/cm",mygaus->GetParameter(1));      stt->AddText(buffer);
+		  sprintf(buffer,"Proton  #sigma:%5.1fMeV/cm",mygaus->GetParameter(2));      stt->AddText(buffer);
+		  stt->Draw("same");
+
+		  c1->SetLogy(true);
+		  sprintf(buffer,"%sProjectionFit_P%03i_%03i","fit/",(int)(100*FitResult->GetXaxis()->GetBinLowEdge(x)),(int)(100*FitResult->GetXaxis()->GetBinUpEdge(x)) );
+		  if(P>=MinRange && P<=MaxRange){SaveCanvas(c1,"dirtest/",buffer);}
+		  delete c1;
+                  delete Projection;
+                  delete mygaus;
+                  delete stt;
+	       }
+
+	       c1  = new TCanvas("canvas", "canvas", 800,600);
+	       FitResult->Draw("");
+
+	       TLine* line1 = new TLine(MinRange, FitResult->GetMinimum(), MinRange, FitResult->GetMaximum());
+	       line1->SetLineWidth(2);
+	       line1->SetLineStyle(2);
+	       line1->Draw();
+
+	       TLine* line2 = new TLine(MaxRange, FitResult->GetMinimum(), MaxRange, FitResult->GetMaximum());
+	       line2->SetLineWidth(2);
+	       line2->SetLineStyle(2);
+	       line2->Draw();
+
+
+	       double prevConstants [] = {*K, *Kerr, *C, *Cerr};
+
+               char fitfunc[2048];
+               sprintf(fitfunc,"[0]*pow(%6.4f/x,2) +[1]",MassCenter);
+               cout << "fitfunc " << fitfunc << endl;
+	       TF1* myfit = new TF1("myfit",fitfunc, MinRange, MaxRange);
+	       myfit->SetParName  (0,"K");
+	       myfit->SetParName  (1,"C");
+	       myfit->SetParameter(0, 1.8);
+	       myfit->SetParameter(1, 4.0);
+	       myfit->SetParLimits(0, 1.3,4.0); //
+	       myfit->SetParLimits(1, 3.0,7.0); // 
+	       myfit->SetLineWidth(2);
+	       myfit->SetLineColor(2);
+	       FitResult->Fit("myfit", "M R E I 0");
+	       myfit->SetRange(MinRange,MaxRange);
+               inputnew->Draw("COLZ");
+               FitResult->Draw("same");
+	       myfit->Draw("same");
+
+	       //double prevConstants [] = {*K, *Kerr, *C, *Cerr};
+	       *K    = myfit->GetParameter(0);
+               *C    = myfit->GetParameter(1);
+               *Kerr = myfit->GetParError(0);
+               *Cerr = myfit->GetParError(1);
+	       cout<< "FitResult : "<<*K<<"   " <<*Kerr<< endl;
+	       cout<< "FitResult : "<<*C<<"   " <<*Cerr<< endl;
+               printf("K Constant changed from %6.4f+-%6.4f to %6.4f+-%6.4f    (diff = %6.3f%%)\n",
+                prevConstants[0], prevConstants[1], *K, *Kerr, 100.0*((*K)-prevConstants[0])/(*K));
+	       printf("C Constant changed from %6.4f+-%6.4f to %6.4f+-%6.4f    (diff = %6.3f%%)\n",
+                prevConstants[2], prevConstants[3], *C, *Cerr, 100.0*((*C)-prevConstants[2])/(*C));
+
+          if(std::max(fabs(100.0*((*K)-prevConstants[0])/(*K)), fabs(100.0*((*C)-prevConstants[2])/(*C)))<1.0)
+             hasConverged=true;  //<1% variation of the constant --> converged
+
+	       TPaveText* st = new TPaveText(0.40,0.78,0.79,0.89, "NDC");
+	       st->SetFillColor(0);
+	       sprintf(buffer,"K = %4.3f +- %6.4f",myfit->GetParameter(0), myfit->GetParError(0));
+	       st->AddText(buffer);
+	       //sprintf(buffer,"C = %4.3f +- %6.4f",myfit->GetParameter(1), myfit->GetParError(1));
+	       sprintf(buffer,"C = %4.3f +- %6.4f",*C, *Cerr);
+	       st->AddText(buffer);
+	       st->Draw("same");
+	       sprintf(buffer,"%sFit","fit/");
+	       SaveCanvas(c1,"dirtest/",buffer);              
+	       delete c1;
+
+          delete line1;
+          delete line2;
+          delete myfit;
+          delete FitResult;
+          delete inputnew;
+       }
+}
+
+
+
+double GetMass(double P, double I, double* K, double* C){
+  //  *C=4.591; // to remove
+  //  *K = 2.002; //to remove
+         
+      return sqrt((I-(*C))/(*K))*P;
+}
+
+
+void SaveCanvas(TCanvas* c, std::string path, std::string name, bool OnlyPPNG){
+   std::string tmppath = path;
+   if(tmppath[tmppath.length()-1]!='/')tmppath += "_";
+   tmppath += name;
+
+   std::string filepath;
+   filepath = tmppath + ".png"; c->SaveAs(filepath.c_str()); if(OnlyPPNG)return;
+   filepath = tmppath +  ".eps"; c->SaveAs(filepath.c_str());
+   filepath = tmppath + ".C"  ; c->SaveAs(filepath.c_str());
+   filepath = tmppath +  ".pdf"; c->SaveAs(filepath.c_str());
+}
+
+
+TF1* GetMassLine(double M, double K, double C, bool left=false)
+{  
+   double BetaMax = 0.99;
+   double PMax = sqrt((BetaMax*BetaMax*M*M)/(1-BetaMax*BetaMax));
+
+   double BetaMin = 0.1;
+   double PMin = sqrt((BetaMin*BetaMin*M*M)/(1-BetaMin*BetaMin));
+   
+   if(left){PMax*=-1; PMin*=-1;}
+
+   TF1* MassLine = new TF1("MassLine","[2] + ([0]*[0]*[1])/(x*x)", PMin, PMax);
+   MassLine->SetParName  (0,"M");
+   MassLine->SetParName  (1,"K");
+   MassLine->SetParName  (2,"C");
+   MassLine->SetParameter(0, M);
+   MassLine->SetParameter(1, K);
+   MassLine->SetParameter(2, C);
+   MassLine->SetLineWidth(2);
+   return MassLine;
+}
+void compaFits(TString filename1, TString filename2, double Kval, double Cval){
+
+   
+   TFile* myfile1;
+   myfile1 = new TFile (filename1);
+   TFile* myfile2;
+   myfile2 = new TFile (filename2);
+
+   TH2D* HdedxVsP_1fit1;
+   TH2D* HdedxVsP_2fit1;
+   TH2D* HdedxVsP_1fit2;
+   TH2D* HdedxVsP_2fit2;
+   TH1D* resuHdedxVsP_1fit1;
+   TH1D* resuHdedxVsP_2fit1 ;
+   TH1D* resuHdedxVsP_1fit2;
+   TH1D* resuHdedxVsP_2fit2 ;
+
+
+   myfile1->cd();
+//    // Ih no drop, no L1
+   HdedxVsP_1fit1 = (TH2D*)gROOT->FindObject("dEdX0noL1VsP_lowp");
+   HdedxVsP_2fit1 = (TH2D*)gROOT->FindObject("dEdX0noL1VsP_lowp2");
+   HdedxVsP_2fit1->Rebin2D(2,1);
+
+   resuHdedxVsP_1fit1 = new TH1D("resuHdedxVsP_1fit1", "resuHdedxVsP_1fit1", HdedxVsP_1fit1->GetXaxis()->GetNbins(),HdedxVsP_1fit1->GetXaxis()->GetXmin(),HdedxVsP_1fit1->GetXaxis()->GetXmax());
+	       resuHdedxVsP_1fit1->SetTitle("");
+	       resuHdedxVsP_1fit1->SetStats(kFALSE);  
+	       resuHdedxVsP_1fit1->GetXaxis()->SetTitle("P [GeV]");
+	       resuHdedxVsP_1fit1->GetYaxis()->SetTitle("dE/dx Estimator [MeV/cm]");
+	       resuHdedxVsP_1fit1->GetYaxis()->SetTitleOffset(1.20);
+	       resuHdedxVsP_1fit1->Reset();     
+
+  resuHdedxVsP_2fit1 = new TH1D("resuHdedxVsP_2fit1", "resuHdedxVsP_2fit1" ,HdedxVsP_2fit1->GetXaxis()->GetNbins(),HdedxVsP_2fit1->GetXaxis()->GetXmin(),HdedxVsP_2fit1->GetXaxis()->GetXmax());
+               resuHdedxVsP_2fit1->SetTitle("");
+               resuHdedxVsP_2fit1->SetStats(kFALSE);
+               resuHdedxVsP_2fit1->GetXaxis()->SetTitle("P [GeV]");
+               resuHdedxVsP_2fit1->GetYaxis()->SetTitle("dE/dx Estimator [MeV/cm]");
+               resuHdedxVsP_2fit1->GetYaxis()->SetTitleOffset(1.20);
+               resuHdedxVsP_2fit1->Reset();
+
+
+   ExtractProj(HdedxVsP_2fit1, HdedxVsP_1fit1, &Kval, &Cval, 0.5, 1.5, 0.938, 0.2, 0.5, 4.2,resuHdedxVsP_2fit1,resuHdedxVsP_1fit1);
+
+   myfile2->cd();
+   HdedxVsP_1fit2 = (TH2D*)gROOT->FindObject("dEdX0noL1VsP_lowp");
+   HdedxVsP_2fit2 = (TH2D*)gROOT->FindObject("dEdX0noL1VsP_lowp2");
+   HdedxVsP_2fit2->Rebin2D(2,1);
+   resuHdedxVsP_1fit2 = new TH1D("resuHdedxVsP_1fit2"       , "resuHdedxVsP_1fit2"      ,HdedxVsP_1fit2->GetXaxis()->GetNbins(),HdedxVsP_1fit2->GetXaxis()->GetXmin(),HdedxVsP_1fit2->GetXaxis()->GetXmax());
+	       resuHdedxVsP_1fit2->SetTitle("");
+	       resuHdedxVsP_1fit2->SetStats(kFALSE);  
+	       resuHdedxVsP_1fit2->GetXaxis()->SetTitle("P [GeV]");
+	       resuHdedxVsP_1fit2->GetYaxis()->SetTitle("dE/dx Estimator [MeV/cm]");
+	       resuHdedxVsP_1fit2->GetYaxis()->SetTitleOffset(1.20);
+	       resuHdedxVsP_1fit2->Reset();     
+
+   resuHdedxVsP_2fit2 = new TH1D("resuHdedxVsP_2fit2", "resuHdedxVsP_2fit2" ,HdedxVsP_2fit2->GetXaxis()->GetNbins(),HdedxVsP_2fit2->GetXaxis()->GetXmin(),HdedxVsP_2fit2->GetXaxis()->GetXmax());
+               resuHdedxVsP_2fit2->SetTitle("");
+               resuHdedxVsP_2fit2->SetStats(kFALSE);
+               resuHdedxVsP_2fit2->GetXaxis()->SetTitle("P [GeV]");
+               resuHdedxVsP_2fit2->GetYaxis()->SetTitle("dE/dx Estimator [MeV/cm]");
+               resuHdedxVsP_2fit2->GetYaxis()->SetTitleOffset(1.20);
+               resuHdedxVsP_2fit2->Reset();
+
+   ExtractProj(HdedxVsP_2fit2, HdedxVsP_1fit2, &Kval, &Cval, 0.5, 1.5, 0.938, 0.2, 0.5, 4.2,resuHdedxVsP_2fit2,resuHdedxVsP_1fit2);
+
+
+   TLegend* leg = new TLegend (0.25, 0.70, 0.65, 0.90);
+//   leg->SetHeader ("Fitting the Profile");
+   leg->SetFillColor(0);
+   leg->SetFillStyle(0);
+   leg->SetBorderSize(0);
+   leg->AddEntry (resuHdedxVsP_1fit1, filename1, "LP");
+   leg->AddEntry (resuHdedxVsP_1fit2, filename2, "LP");
+
+
+   TCanvas* c2 = new TCanvas("c2", "c2", 800,600);
+   c2->cd();
+   TF1* ProtonLine = GetMassLine(0.938,Kval, Cval, false);
+   ProtonLine->SetLineColor(1);
+   ProtonLine->SetLineWidth(2);
+
+   TLine* linepion = new TLine(2.,Cval,25., Cval);
+   linepion->SetLineColor(6);
+   linepion->SetLineWidth(2);
+
+   resuHdedxVsP_1fit1->SetLineColor(2);
+   resuHdedxVsP_1fit1->SetMarkerColor(2);
+   resuHdedxVsP_2fit1->SetLineColor(2);
+   resuHdedxVsP_2fit1->SetMarkerColor(2);
+   resuHdedxVsP_1fit2->SetLineColor(4);
+   resuHdedxVsP_1fit2->SetMarkerColor(4);
+   resuHdedxVsP_2fit2->SetLineColor(4);
+   resuHdedxVsP_2fit2->SetMarkerColor(4);
+
+   resuHdedxVsP_1fit1->SetMaximum(13.);
+   resuHdedxVsP_1fit1->Draw();
+   resuHdedxVsP_1fit2->Draw("same");
+   ProtonLine->Draw("same");
+   linepion->Draw("same");
+   leg->Draw("same");
+   SaveCanvas(c2, "dirtest/", "compa_lines");
+   
+
+  TCanvas* c3 = new TCanvas("c3", "c3", 800,600);
+   c3->cd();
+   resuHdedxVsP_2fit1->SetMinimum(2.5);
+   resuHdedxVsP_2fit1->SetMaximum(5.);
+   resuHdedxVsP_2fit1->Draw();
+   resuHdedxVsP_2fit2->Draw("same");
+//   ProtonLine->Draw("same");
+   linepion->Draw("same");
+   leg->Draw("same");
+   SaveCanvas(c3, "dirtest/", "compa_long");
+   
+  gStyle->SetOptStat(0);
+  c2->cd();
+  c2->SetLogz(1);
+  SaveCanvas(c2, "dirtest/", "compa_lines_logZ"); 
+   c3->cd();
+  c3->SetLogz(1);
+   SaveCanvas(c3, "dirtest/", "compa_long_logZ");
+
+
+   
+
+}
+
+void ExtractProj(TH2D* inputlong, TH2D* inputshort,double* K, double* C, 
+      double MinRange, double MaxRange, double MassCenter, double LeftMassMargin, double RightMassMargin, double yPionMax,
+      TH1D* FitResultPion,  TH1D* FitResult)
+{
+	      TH2D* inputnew = (TH2D*)inputshort->Clone("tempTH2D");
+	      TH2D* inputnewPion = (TH2D*)inputlong->Clone("tempTH2D2");
+	      for(int x=0;x<=inputnew->GetNbinsX()+1;x++){
+	      for(int y=0;y<=inputnew->GetNbinsY()+1;y++){
+		double Mass = GetMass(inputnew->GetXaxis()->GetBinCenter(x),inputnew->GetYaxis()->GetBinCenter(y), K, C);
+		if(isnan (float(Mass)) || Mass<MassCenter-(LeftMassMargin) || Mass>MassCenter+RightMassMargin){
+		  inputnew->SetBinContent(x,y,0);        
+		  inputnew->SetBinError(x,y,0);        
+		}
+	      }}
+	      for(int x=0;x<=inputnewPion->GetNbinsX()+1;x++){
+   	        for(int y=0;y<=inputnewPion->GetNbinsY()+1;y++){
+                    if (inputnewPion->GetXaxis()->GetBinCenter(x)<2.5) {
+                          inputnewPion->SetBinContent(x,y,0);
+                          inputnewPion->SetBinError(x,y,0);
+                    }
+	  	    if (inputnewPion->GetYaxis()->GetBinCenter(y)<2 || inputnewPion->GetYaxis()->GetBinCenter(y)>yPionMax) {
+                          inputnewPion->SetBinContent(x,y,0);
+                          inputnewPion->SetBinError(x,y,0);
+                    }
+	      }}
+
+	      
+
+               for(int x=1;x<inputnewPion->GetNbinsX();x++){
+		  TH1D* ProjectionPion = (TH1D*)(inputnewPion->ProjectionY("proj",x,x))->Clone();
+                  if(ProjectionPion->Integral()<100)continue;
+                  ProjectionPion->SetAxisRange(0.1,25,"X");
+//                  ProjectionPion->Sumw2();
+                  ProjectionPion->Scale(1.0/ProjectionPion->Integral());
+
+                  TF1* mygausPion = new TF1("mygausPion","gaus", 2., 15);
+                  ProjectionPion->Fit("mygausPion","Q0 RME");
+                  FitResultPion->SetBinContent(x, mygausPion->GetParameter(1));
+//		  cout<< " mygausPion     " <<x<<"  "<<mygausPion->GetParameter(1)<<endl;
+		  FitResultPion->SetBinError  (x, mygausPion->GetParError (1));
+                  delete ProjectionPion;
+                  delete mygausPion;
+               }
+
+	       for(int x=1;x<inputnew->GetXaxis()->FindBin(1.5);x++){
+		  double P       = inputnew->GetXaxis()->GetBinCenter(x);
+	    
+		  TH1D* Projection = (TH1D*)(inputnew->ProjectionY("proj",x,x))->Clone();
+		  if(Projection->Integral()<100)continue;
+		  Projection->SetAxisRange(0.1,25,"X");
+//		  Projection->Sumw2();
+		  Projection->Scale(1.0/Projection->Integral());
+
+		  TF1* mygaus = new TF1("mygaus","gaus", 2.5, 15);
+		  Projection->Fit("mygaus","Q0 RME");
+		  double chiFromFit  = (mygaus->GetChisquare())/(mygaus->GetNDF());
+		  FitResult->SetBinContent(x, mygaus->GetParameter(1));
+		  FitResult->SetBinError  (x, mygaus->GetParError (1));
+		  mygaus->SetLineColor(2);
+		  mygaus->SetLineWidth(2);
+
+                  delete Projection;
+                  delete mygaus;
+	       }
+
+          delete inputnewPion;
+          delete inputnew;
+}
+void TestFitKandC(TString filename){
+   double K_ = 3.0; double Kerr_ = 0.001; double C_ = 3.; double Cerr_ = 0.001;
+   double Ktmp = K_ ; double Ctmp = C_; double KerrTmp = Kerr_; double CerrTmp = Cerr_;
+   double Ntmp = 0.3 ;  double NerrTmp = 0.001;
+   TFile* myfile;
+   myfile = new TFile (filename);
+
+   TH2D* HdedxVsP_1fit;
+   TH2D* HdedxVsP_2fit;
+   myfile->cd();
+//    // Ih no drop, no L1
+   HdedxVsP_1fit = (TH2D*)gROOT->FindObject("dEdX0noL1VsP_lowp");
+   HdedxVsP_2fit = (TH2D*)gROOT->FindObject("dEdX0noL1VsP_lowp2");
+   HdedxVsP_2fit->Rebin2D(2,1);
+   TestExtractConstants (HdedxVsP_2fit, HdedxVsP_1fit, &Ktmp, &Ctmp, &Ntmp, &KerrTmp, &CerrTmp, &NerrTmp, 0.5, 20., 0.938, 0.2, 0.5, 4.2);
+   
+
+   TCanvas* c2 = new TCanvas("c2", "c2", 800,600);
+   c2->cd();
+   gStyle->SetOptStat(0);
+   TF1* PionLine = TestGetMassLine(0.140, Ktmp, Ctmp, Ntmp, false);
+   PionLine->SetLineColor(1);
+   PionLine->SetLineWidth(2);
+   TF1* KaonLine = TestGetMassLine(0.494, Ktmp, Ctmp, Ntmp, false);
+   KaonLine->SetLineColor(1);
+   KaonLine->SetLineWidth(2);
+   TF1* ProtonLine = TestGetMassLine(0.938,Ktmp, Ctmp, Ntmp, false);
+   ProtonLine->SetLineColor(1);
+   ProtonLine->SetLineWidth(2);
+   TF1* DeuteronLine = TestGetMassLine(1.8756,Ktmp, Ctmp, Ntmp, false);
+   DeuteronLine->SetLineColor(1);
+   DeuteronLine->SetLineWidth(2);
+
+   HdedxVsP_2fit->Draw("colz");
+   PionLine->Draw("same");
+   KaonLine->Draw("same");
+   ProtonLine->Draw("same");
+   if (filename=="analysis_ul_2017_21jan.root") DeuteronLine->Draw("same");
+   SaveCanvas(c2, "dirtest/", "TestdedxVsP_long");
+   
+   c2->SetLogz(1);
+    SaveCanvas(c2, "dirtest/", "TestdedxVsP_long_logZ"); 
+   
+   TCanvas* c3 = new TCanvas("c3", "c3", 800,600);
+   c3->cd();
+   gStyle->SetOptStat(0);
+   HdedxVsP_1fit->Draw("colz");
+   PionLine->Draw("same");
+   KaonLine->Draw("same");
+   ProtonLine->Draw("same");
+   if (filename=="analysis_ul_2017_21jan.root") DeuteronLine->Draw("same");
+   SaveCanvas(c3, "dirtest/", "TestdedxVsP_lines");
+   c3->SetLogz(1);
+    SaveCanvas(c3, "dirtest/", "TestdedxVsP_lines_logZ"); 
+
+}
+void TestExtractConstants(TH2D* inputlong, TH2D* inputshort, double* K, double* C, double* N, double* Kerr, double* Cerr, double* Nerr, double MinRange , double MaxRange , double MassCenter , double LeftMassMargin , double RightMassMargin , double yPionMax) {
+       char buffer[2048];
+       bool hasConverged = false;
+
+       for(unsigned int loop=0;loop<8 and !hasConverged; loop++){
+              TH2D* Myinputnew = new TH2D("Myinputnew","Myinputnew", 250,0,25, 80, 2.,10.);
+              Myinputnew->Sumw2();
+	      TH2D* inputnew = (TH2D*)inputshort->Clone("tempTH2D");
+	      TH2D* inputnewPion = (TH2D*)inputlong->Clone("tempTH2D2");
+	      for(int x=0;x<=inputnew->GetNbinsX()+1;x++){
+	      for(int y=0;y<=inputnew->GetNbinsY()+1;y++){
+		double Mass = GetMass(inputnew->GetXaxis()->GetBinCenter(x),inputnew->GetYaxis()->GetBinCenter(y), K, C);
+		if(isnan (float(Mass)) || Mass<MassCenter-(LeftMassMargin) || Mass>MassCenter+RightMassMargin){
+		  inputnew->SetBinContent(x,y,0);        
+		  inputnew->SetBinError(x,y,0);        
+		}
+                else {
+                  if (Myinputnew->GetXaxis()->GetBinCenter(x)<1.5) {
+                         Myinputnew->SetBinContent(x,y,inputnew->GetBinContent(x,y)); 
+                         Myinputnew->SetBinError(x,y,inputnew->GetBinError(x,y)); 
+                  }
+             
+                }
+	      }}
+	      for(int x=0;x<=inputnewPion->GetNbinsX()+1;x++){
+   	        for(int y=0;y<=inputnewPion->GetNbinsY()+1;y++){
+                    if (inputnewPion->GetXaxis()->GetBinCenter(x)<3.0) {
+                        inputnewPion->SetBinContent(x,y,0);
+                        inputnewPion->SetBinError(x,y,0);
+                    }
+	  	    if (inputnewPion->GetYaxis()->GetBinCenter(y)<2 || inputnewPion->GetYaxis()->GetBinCenter(y)>yPionMax) {
+                       inputnewPion->SetBinContent(x,y,0);
+                       inputnewPion->SetBinError(x,y,0);
+                    }
+                    Myinputnew->Fill(inputnewPion->GetXaxis()->GetBinCenter(x),inputnewPion->GetYaxis()->GetBinCenter(y),inputnewPion->GetBinContent(x,y));
+	      }}
+
+	      
+
+	      TCanvas* c1 = new TCanvas("c1", "c1", 800,600);
+	      c1->SetLogz(true);
+	      Myinputnew->SetStats(kFALSE);
+	      Myinputnew->GetXaxis()->SetTitle("track momentum (GeV)");
+	      Myinputnew->GetYaxis()->SetTitle("dE/dx (MeV/cm)");
+	      Myinputnew->SetAxisRange(0,25,"X");
+	      Myinputnew->SetAxisRange(0,15,"Y");
+	      Myinputnew->Draw("COLZ");
+
+	//      KaonLine->Draw("same");
+	//      ProtonLine->Draw("same");
+	//      DeuteronLine->Draw("same");
+	//      TritonLine->Draw("same");
+
+	      SaveCanvas(c1, "dirtest/", "testMyinputnew");
+
+	      delete c1;
+               TH1D* FitResult = new TH1D("FitResult"       , "FitResult"      ,Myinputnew->GetXaxis()->GetNbins(),Myinputnew->GetXaxis()->GetXmin(),Myinputnew->GetXaxis()->GetXmax());
+	       FitResult->SetTitle("");
+	       FitResult->SetStats(kFALSE);  
+	       FitResult->GetXaxis()->SetTitle("P [GeV]");
+	       FitResult->GetYaxis()->SetTitle("dE/dx Estimator [MeV/cm]");
+	       FitResult->GetYaxis()->SetTitleOffset(1.20);
+	       FitResult->Reset();     
+
+               for(int x=1;x<Myinputnew->GetNbinsX();x++){
+		  TH1D* ProjectionPion = (TH1D*)(Myinputnew->ProjectionY("proj",x,x))->Clone();
+                  if(ProjectionPion->Integral()<100)continue;
+                  ProjectionPion->SetAxisRange(0.1,25,"X");
+                  ProjectionPion->Scale(1.0/ProjectionPion->Integral());
+
+                  TF1* mygausPion = new TF1("mygausPion","gaus", 2., 15);
+                  ProjectionPion->Fit("mygausPion","Q0 RME");
+                  FitResult->SetBinContent(x, mygausPion->GetParameter(1));
+		  FitResult->SetBinError  (x, mygausPion->GetParError (1));
+               }
+
+	       c1  = new TCanvas("canvas", "canvas", 800,600);
+	       FitResult->SetAxisRange(0,25,"X");
+	       FitResult->SetAxisRange(0,15,"Y");
+	       FitResult->Draw("");
+	      SaveCanvas(c1, "dirtest/", "testFitResult");
+
+	       double prevConstants [] = {*K, *Kerr, *C, *Cerr, *N, *Nerr};
+
+
+               char fitfunc1[2048];
+               sprintf(fitfunc1,"[0]*pow(%6.4f/x,2) +[1] + [2]*log(x/%6.4f)",MassCenter,MassCenter);
+//	       TF1* myfit = new TF1("myfit",fitfunc1, MinRange, MaxRange);
+	       TF1* myfit = new TF1("myfit",TestfitSpecial, MinRange, MaxRange,3);
+//	       TF1* myfit = new TF1("myfit",TestfitSpecial2, MinRange, MaxRange,3);
+	       myfit->SetParName  (0,"K");
+	       myfit->SetParName  (1,"C");
+	       myfit->SetParName  (2,"N");
+	       myfit->SetParameter(0, 2.);
+	       myfit->SetParameter(1, 3.3);
+	       myfit->SetParameter(2, 0.2);
+	       myfit->SetParLimits(0, 1.0,4.0); //
+	       myfit->SetParLimits(1, 2.,5); // 
+	       myfit->SetParLimits(2, 0.0001,1000); // 
+
+	       myfit->SetLineWidth(2);
+	       myfit->SetLineColor(2);
+	       FitResult->Fit("myfit", "M R E I 0");
+	       myfit->SetRange(MinRange,MaxRange);
+               Myinputnew->Draw("COLZ");
+               FitResult->SetMarkerSize(21);
+               FitResult->SetLineWidth(2);
+               FitResult->Draw("same");
+	       myfit->Draw("same");
+               FitResult->Draw("same");
+               c1->SetLogz(1);
+
+	       //double prevConstants [] = {*K, *Kerr, *C, *Cerr};
+	       *K    = myfit->GetParameter(0);
+               *C    = myfit->GetParameter(1);
+               *N    = myfit->GetParameter(2);
+               *Kerr = myfit->GetParError(0);
+               *Cerr = myfit->GetParError(1);
+               *Nerr = myfit->GetParError(2);
+	       cout<< "FitResult : "<<*K<<"   " <<*Kerr<< "   " << *C <<"   " <<*Cerr<< "   " << *N<<"   " <<*Nerr<<endl;
+	       //cout<< "FitResult : "<<myfit->GetParameter(1)<<"   " <<myfit->GetParError(1)<< endl;
+               printf("K Constant changed from %6.4f+-%6.4f to %6.4f+-%6.4f    (diff = %6.3f%%)\n",
+                prevConstants[0], prevConstants[1], *K, *Kerr, 100.0*((*K)-prevConstants[0])/(*K));
+	       printf("C Constant changed from %6.4f+-%6.4f to %6.4f+-%6.4f    (diff = %6.3f%%)\n",
+                prevConstants[2], prevConstants[3], *C, *Cerr, 100.0*((*C)-prevConstants[2])/(*C));
+	       if (*N>0) printf("N Constant changed from %6.4f+-%6.4f to %6.4f+-%6.4f    (diff = %6.3f%%)\n",
+                prevConstants[4], prevConstants[5], *N, *Nerr, 100.0*((*N)-prevConstants[4])/(*N));
+
+          if(std::max(fabs(100.0*((*K)-prevConstants[0])/(*K)), fabs(100.0*((*C)-prevConstants[2])/(*C)))<1.0) {
+             if (*N>0) {
+                if ( fabs(100.0*((*N)-prevConstants[4])/(*N))<1.0) hasConverged=true; 
+             }
+             else {
+               hasConverged=true;  //<1% variation of the constant --> converged
+             }
+          }
+
+	       TPaveText* st = new TPaveText(0.40,0.78,0.79,0.89, "NDC");
+	       st->SetFillColor(0);
+	       sprintf(buffer,"K = %4.3f +- %6.4f",myfit->GetParameter(0), myfit->GetParError(0));
+	       st->AddText(buffer);
+	       //sprintf(buffer,"C = %4.3f +- %6.4f",myfit->GetParameter(1), myfit->GetParError(1));
+	       sprintf(buffer,"C = %4.3f +- %6.4f",*C, *Cerr);
+	       st->AddText(buffer);
+	       sprintf(buffer,"N = %4.3f +- %6.4f",*N, *Nerr);
+	       st->AddText(buffer);
+	       st->Draw("same");
+	       sprintf(buffer,"%sFit","fit/");
+	       SaveCanvas(c1,"dirtest/",buffer);              
+	       delete c1;
+
+          delete myfit;
+          delete FitResult;
+          delete Myinputnew;
+       }
+}
+
+Double_t TestfitSpecial(Double_t *x, Double_t *par) {
+  if (x[0]<2.5) {
+    return par[0]*pow(0.938/x[0],2) + par[1] + par[2]*log(x[0]/0.938);
+  }
+  else {
+    return par[0]*pow(0.140/x[0],2) + par[1] + par[2]*log(x[0]/0.140);
+  }
+}
+
+Double_t TestfitSpecial2(Double_t *x, Double_t *par) {
+  if (x[0]<2.5) {
+    return par[0]*pow(0.938/x[0],2)*log(par[2]*x[0]/0.938) + par[1] ;
+  }
+  else {
+    return par[0]*pow(0.140/x[0],2)*log(par[2]*x[0]/0.140) + par[1] ;
+  }
+}
+
+TF1* TestGetMassLine(double M, double K, double C, double N, bool left=false)
+{  
+
+   TF1* MassLine = new TF1("MassLine","[2] + ([0]*[0]*[1])/(x*x) +[3]*log(x/[0])", 0.5, 20.);
+   MassLine->SetParName  (0,"M");
+   MassLine->SetParName  (1,"K");
+   MassLine->SetParName  (2,"C");
+   MassLine->SetParName  (3,"N");
+   MassLine->SetParameter(0, M);
+   MassLine->SetParameter(1, K);
+   MassLine->SetParameter(2, C);
+   MassLine->SetParameter(3, N);
+   MassLine->SetLineWidth(2);
+   return MassLine;
+}
+
+
+void CaroBla(){
+   TFile* myfile1 = new TFile ("crab_Analysis_SingleMuon_Run2017B_CodeV42p6_v1.root");
+   TFile* myfile2 = new TFile ("crab_Analysis_SingleMuon_Run2017C_CodeV42p6_v1.root");
+   TFile* myfile3 = new TFile ("crab_Analysis_SingleMuon_Run2017D_CodeV42p6_v1.root");
+   TFile* myfile4 = new TFile ("crab_Analysis_SingleMuon_Run2017E_CodeV42p6_v1.root");
+   TFile* myfile5 = new TFile ("crab_Analysis_SingleMuon_Run2017F_CodeV42p6_v1.root");
+
+   TFile* myfile6 = new TFile ("crab_Analysis_SingleMuon_Run2018A_CodeV42p6_v1.root");
+   TFile* myfile7 = new TFile ("crab_Analysis_SingleMuon_Run2018B_CodeV42p6_v1.root");
+   TFile* myfile8 = new TFile ("crab_Analysis_SingleMuon_Run2018C_CodeV42p6_v1.root");
+   TFile* myfile9 = new TFile ("crab_Analysis_SingleMuon_Run2018D_CodeV42p6_v1.root");
+
+   TFile* myfilemc1 = new TFile ("crab_Analysis_2018_AllBackground_CodeV42p6_v1.root");
+   TFile* myfilemc2 = new TFile ("crab_Analysis_2018_AllWJets_CodeV42p6_v1.root");
+
+   TH2D* HdedxVsP_1fit1;
+   TH2D* HdedxVsP_1fit2;
+   TH2D* HdedxVsP_1fit3;
+   TH2D* HdedxVsP_1fit4;
+   TH2D* HdedxVsP_1fit5;
+   TH2D* HdedxVsP_1fit6;
+   TH2D* HdedxVsP_1fit7;
+   TH2D* HdedxVsP_1fit8;
+   TH2D* HdedxVsP_1fit9;
+   TH2D* HdedxVsP_1fitmc1;
+   TH2D* HdedxVsP_1fitmc2;
+   myfile1->GetObject("HSCParticleAnalyzer/BaseName/K_and_C_Ih_noL1_VsP_1",HdedxVsP_1fit1);
+   myfile2->GetObject("HSCParticleAnalyzer/BaseName/K_and_C_Ih_noL1_VsP_1",HdedxVsP_1fit2);
+   myfile3->GetObject("HSCParticleAnalyzer/BaseName/K_and_C_Ih_noL1_VsP_1",HdedxVsP_1fit3);
+   myfile4->GetObject("HSCParticleAnalyzer/BaseName/K_and_C_Ih_noL1_VsP_1",HdedxVsP_1fit4);
+   myfile5->GetObject("HSCParticleAnalyzer/BaseName/K_and_C_Ih_noL1_VsP_1",HdedxVsP_1fit5);
+
+   myfile6->GetObject("HSCParticleAnalyzer/BaseName/K_and_C_Ih_noL1_VsP_1",HdedxVsP_1fit6);
+   myfile7->GetObject("HSCParticleAnalyzer/BaseName/K_and_C_Ih_noL1_VsP_1",HdedxVsP_1fit7);
+   myfile8->GetObject("HSCParticleAnalyzer/BaseName/K_and_C_Ih_noL1_VsP_1",HdedxVsP_1fit8);
+   myfile9->GetObject("HSCParticleAnalyzer/BaseName/K_and_C_Ih_noL1_VsP_1",HdedxVsP_1fit9);
+
+   myfilemc1->GetObject("HSCParticleAnalyzer/BaseName/K_and_C_Ih_noL1_VsP_1",HdedxVsP_1fitmc1);
+   myfilemc2->GetObject("HSCParticleAnalyzer/BaseName/K_and_C_Ih_noL1_VsP_1",HdedxVsP_1fitmc2);
+
+   float xint1=  HdedxVsP_1fit1->Integral(0,HdedxVsP_1fit1->GetNbinsX(),0,HdedxVsP_1fit1->GetNbinsY());
+   float xint2=  HdedxVsP_1fit2->Integral(0,HdedxVsP_1fit1->GetNbinsX(),0,HdedxVsP_1fit1->GetNbinsY()) ;
+   float xint3=  HdedxVsP_1fit3->Integral(0,HdedxVsP_1fit1->GetNbinsX(),0,HdedxVsP_1fit1->GetNbinsY()) ;
+   float xint4=  HdedxVsP_1fit4->Integral(0,HdedxVsP_1fit1->GetNbinsX(),0,HdedxVsP_1fit1->GetNbinsY()) ;
+   float xint5=  HdedxVsP_1fit5->Integral(0,HdedxVsP_1fit1->GetNbinsX(),0,HdedxVsP_1fit1->GetNbinsY()) ;
+
+   float xint6=  HdedxVsP_1fit6->Integral(0,HdedxVsP_1fit1->GetNbinsX(),0,HdedxVsP_1fit1->GetNbinsY()) ;
+   float xint7=  HdedxVsP_1fit7->Integral(0,HdedxVsP_1fit1->GetNbinsX(),0,HdedxVsP_1fit1->GetNbinsY()) ;
+   float xint8=  HdedxVsP_1fit8->Integral(0,HdedxVsP_1fit1->GetNbinsX(),0,HdedxVsP_1fit1->GetNbinsY()) ;
+   float xint9=  HdedxVsP_1fit9->Integral(0,HdedxVsP_1fit1->GetNbinsX(),0,HdedxVsP_1fit1->GetNbinsY()) ;
+   float xintmc1=  HdedxVsP_1fitmc1->Integral(0,HdedxVsP_1fit1->GetNbinsX(),0,HdedxVsP_1fit1->GetNbinsY()) ;
+   float xintmc2=  HdedxVsP_1fitmc2->Integral(0,HdedxVsP_1fit1->GetNbinsX(),0,HdedxVsP_1fit1->GetNbinsY()) ;
+   float xsum2017 = xint1+xint2+xint3+xint4+xint5;
+   float xsum2018 = xint6+xint7+xint8+xint9;
+
+   cout << " in all MC " << xintmc1 << endl;
+   cout << " in W+jets MC " << xintmc2 << endl;
+
+/*   with varying C
+ *
+   float K1 = 2.328;
+   float K2 = 2.3497;
+   float K3 = 2.3687;
+   float K4 = 2.2718;
+   float K5 = 2.3414;
+
+   float K6 = 2.3031;
+   float K7 = 2.2914;
+   float K8 = 2.2925;
+   float K9 = 2.2977;
+*/
+   float K1 = 2.3434;
+   float K2 = 2.3357;
+   float K3 = 2.3678;
+   float K4 = 2.2671;
+   float K5 = 2.3581;
+
+   float K6 = 2.3213;
+   float K7 = 2.2885;
+   float K8 = 2.3002;
+   float K9 = 2.2901;
+   float centK1 = (xint1*K1 + xint2*K2 + xint3*K3 + xint4*K4 + xint5*K5)/xsum2017;
+   float centK2 = (xint6*K6 + xint7*K7 + xint8*K8 + xint9*K9 )/xsum2018;
+   cout << " cent K 2017 " << centK1 <<  "        cent K 2018 " << centK2 << endl;
+   
+   TH1F* humK1 = new TH1F("humK1","K 2017",100,2.20,2.40);
+   TH1F* humK2 = new TH1F("humK2","K 2018",100,2.20,2.40);
+   humK1->Fill(K1,xint1);
+   humK1->Fill(K2,xint2);
+   humK1->Fill(K3,xint3);
+   humK1->Fill(K4,xint4);
+   humK1->Fill(K5,xint5);
+   humK2->Fill(K6,xint6);
+   humK2->Fill(K7,xint7);
+   humK2->Fill(K8,xint8);
+   humK2->Fill(K9,xint9);
+ 
+   TCanvas* c1 = new TCanvas("c1", "c1", 800,600);
+   c1->cd();
+//   HdedxVsP_1fit1->Draw("colz");
+   humK1->Draw();
+   TCanvas* c2 = new TCanvas("c2", "c2", 800,600);
+   c2->cd();
+   humK2->Draw();
+
+   float C1 = 3.1555;
+   float C2 = 3.125;
+   float C3 = 3.1388;
+   float C4 = 3.1353;
+   float C5 = 3.1572;
+
+   float C6 = 3.1592;
+   float C7 = 3.1372;
+   float C8 = 3.1483;
+   float C9 = 3.1318;
+   float centC1 = (xint1*C1 + xint2*C2 + xint3*C3 + xint4*C4 + xint5*C5)/xsum2017;
+   float centC2 = (xint6*C6 + xint7*C7 + xint8*C8 + xint9*C9)/xsum2018;
+   cout << " cent C 2017 " << centC1 <<  "        cent C 2018 " << centC2 << endl;
+   TH1F* humC1 = new TH1F("humC1","C 2017",100,3.0,3.3);
+   TH1F* humC2 = new TH1F("humC2","C 2018",100,3.0,3.3);
+   humC1->Fill(C1,xint1);
+   humC1->Fill(C2,xint2);
+   humC1->Fill(C3,xint3);
+   humC1->Fill(C4,xint4);
+   humC1->Fill(C5,xint5);
+   humC2->Fill(C6,xint6);
+   humC2->Fill(C7,xint7);
+   humC2->Fill(C8,xint8);
+   humC2->Fill(C9,xint9);
+ 
+   TCanvas* c3 = new TCanvas("c3", "c3", 800,600);
+   c3->cd();
+//   HdedxVsP_1fit1->Draw("colz");
+   humC1->Draw();
+   TCanvas* c4 = new TCanvas("c4", "c4", 800,600);
+   c4->cd();
+   humC2->Draw();
+}
+
+

--- a/Analyzer/test/CalibMacros/makeProfilePlot2.C
+++ b/Analyzer/test/CalibMacros/makeProfilePlot2.C
@@ -1,0 +1,588 @@
+#include <exception>
+#include <vector>
+#include <fstream>
+
+#include "TROOT.h"
+#include "TFile.h"
+#include "TDirectory.h"
+#include "TChain.h"
+#include "TObject.h"
+#include "TCanvas.h"
+#include "TMath.h"
+#include "TLegend.h"
+#include "TGraph.h"
+#include "TH1.h"
+#include "TH2.h"
+#include "TH3.h"
+#include "TTree.h"
+#include "TF1.h"
+#include "TGraphAsymmErrors.h"
+#include "TGraphErrors.h"
+#include "TPaveText.h"
+#include "TProfile.h"
+#include "TProfile2D.h"
+#include "TCutG.h"
+
+using namespace std;
+void MakeMyProfile(TH2D* input, TH1D* output);
+void SaveCanvas(TCanvas* c, std::string path, std::string name, bool OnlyPPNG=false);
+void plot(bool mb);
+void GetSF(bool mb, bool corr);
+void GetSF();
+
+
+void plot( bool mb) {
+TFile *_file0 ;
+TFile *_file1;
+
+if (mb)  {
+_file0= TFile::Open("minbias_template_corr.root");
+_file1 = TFile::Open("minbias_template_uncorr.root");
+}
+else {
+_file0 = TFile::Open("ttbar_template_corr.root");
+_file1 = TFile::Open("ttbar_template_uncorr.root");
+}
+
+TH2D* CorrHHitPixVsEtaP5;
+TH2D* CorrHHitPixVsEtapL5;
+
+TH2D* UnCorrHHitPixVsEtaP5;
+TH2D* UnCorrHHitPixVsEtapL5;
+
+TH2D* CorrHHitStripVsEtaP5;
+TH2D* CorrHHitStripVsEtapL5;
+
+TH2D* UnCorrHHitStripVsEtaP5;
+TH2D* UnCorrHHitStripVsEtapL5;
+
+
+TH2D *CorrHHitPixVsP;
+TH2D *CorrHHitStripVsP;
+TH2D *UnCorrHHitPixVsP;
+TH2D *UnCorrHHitStripVsP;
+TH2D *CorrHHitPixVsPExt;
+TH2D *CorrHHitStripVsPExt;
+TH2D *UnCorrHHitPixVsPExt;
+TH2D *UnCorrHHitStripVsPExt;
+
+_file0->cd();
+
+
+CorrHHitStripVsEtaP5 = (TH2D*)gROOT->FindObject("HHitStripVsEtaP5");
+CorrHHitStripVsEtapL5 = (TH2D*) gROOT->FindObject("HHitStripVsEtapL5");
+CorrHHitPixVsEtaP5 = (TH2D*) gROOT->FindObject("HHitPixVsEtaP5");
+CorrHHitPixVsEtapL5 = (TH2D*) gROOT->FindObject("HHitPixVsEtapL5");
+
+TH1D* CorrPixVsEtaP5 = new TH1D("CorrPixVsEtaP5"       , "CorrPixVsEtaP5"      ,CorrHHitPixVsEtaP5->GetXaxis()->GetNbins(),CorrHHitPixVsEtaP5->GetXaxis()->GetXmin(),CorrHHitPixVsEtaP5->GetXaxis()->GetXmax());
+TH1D* CorrPixVsEtapL5 = new TH1D("CorrPixVsEtapL5"       , "CorrPixVsEtapL5"      ,CorrHHitPixVsEtapL5->GetXaxis()->GetNbins(),CorrHHitPixVsEtapL5->GetXaxis()->GetXmin(),CorrHHitPixVsEtapL5->GetXaxis()->GetXmax());
+TH1D* CorrStripVsEtaP5 = new TH1D("CorrStripVsEtaP5"       , "CorrStripVsEtaP5"      ,CorrHHitStripVsEtaP5->GetXaxis()->GetNbins(),CorrHHitStripVsEtaP5->GetXaxis()->GetXmin(),CorrHHitStripVsEtaP5->GetXaxis()->GetXmax());
+TH1D* CorrStripVsEtapL5 = new TH1D("CorrStripVsEtapL5"       , "CorrStripVsEtapL5"      ,CorrHHitStripVsEtapL5->GetXaxis()->GetNbins(),CorrHHitStripVsEtapL5->GetXaxis()->GetXmin(),CorrHHitStripVsEtapL5->GetXaxis()->GetXmax());
+
+MakeMyProfile(CorrHHitPixVsEtaP5, CorrPixVsEtaP5);
+MakeMyProfile(CorrHHitPixVsEtapL5, CorrPixVsEtapL5);
+MakeMyProfile(CorrHHitStripVsEtaP5, CorrStripVsEtaP5);
+MakeMyProfile(CorrHHitStripVsEtapL5, CorrStripVsEtapL5);
+
+CorrHHitPixVsP= (TH2D*)gROOT->FindObject("HHitPixVsPw");
+CorrHHitStripVsP= (TH2D*)gROOT->FindObject("HHitStripVsPw");
+TH1D* CorrPixVsP = new TH1D("CorrPixVsP"       , "CorrPixVsP"      ,CorrHHitPixVsP->GetXaxis()->GetNbins(),CorrHHitPixVsP->GetXaxis()->GetXmin(),CorrHHitPixVsP->GetXaxis()->GetXmax());
+TH1D* CorrStripVsP = new TH1D("CorrStripVsP"       , "CorrStripVsP"      ,CorrHHitStripVsP->GetXaxis()->GetNbins(),CorrHHitStripVsP->GetXaxis()->GetXmin(),CorrHHitStripVsP->GetXaxis()->GetXmax());
+MakeMyProfile(CorrHHitPixVsP,CorrPixVsP);
+MakeMyProfile(CorrHHitStripVsP,CorrStripVsP);
+CorrHHitPixVsPExt= (TH2D*)gROOT->FindObject("HHitPixVsPExtw");
+CorrHHitStripVsPExt= (TH2D*)gROOT->FindObject("HHitStripVsPExtw");
+TH1D* CorrPixVsPExt = new TH1D("CorrPixVsPExt"       , "CorrPixVsPExt"      ,CorrHHitPixVsPExt->GetXaxis()->GetNbins(),CorrHHitPixVsPExt->GetXaxis()->GetXmin(),CorrHHitPixVsPExt->GetXaxis()->GetXmax());
+TH1D* CorrStripVsPExt = new TH1D("CorrStripVsPExt"       , "CorrStripVsPExt"      ,CorrHHitStripVsPExt->GetXaxis()->GetNbins(),CorrHHitStripVsPExt->GetXaxis()->GetXmin(),CorrHHitStripVsPExt->GetXaxis()->GetXmax());
+MakeMyProfile(CorrHHitPixVsPExt,CorrPixVsPExt);
+MakeMyProfile(CorrHHitStripVsPExt,CorrStripVsPExt);
+
+cout <<  "fill from file0"<< endl;
+_file1->cd();
+
+
+UnCorrHHitStripVsEtaP5 = (TH2D*)gROOT->FindObject("HHitStripVsEtaP5");
+UnCorrHHitStripVsEtapL5 = (TH2D*) gROOT->FindObject("HHitStripVsEtapL5");
+UnCorrHHitPixVsEtaP5 = (TH2D*) gROOT->FindObject("HHitPixVsEtaP5");
+UnCorrHHitPixVsEtapL5 = (TH2D*) gROOT->FindObject("HHitPixVsEtapL5");
+
+TH1D* UnCorrPixVsEtaP5 = new TH1D("UnCorrPixVsEtaP5"       , "UnCorrPixVsEtaP5"      ,UnCorrHHitPixVsEtaP5->GetXaxis()->GetNbins(),UnCorrHHitPixVsEtaP5->GetXaxis()->GetXmin(),UnCorrHHitPixVsEtaP5->GetXaxis()->GetXmax());
+TH1D* UnCorrPixVsEtapL5 = new TH1D("UnCorrPixVsEtapL5"       , "UnCorrPixVsEtapL5"      ,UnCorrHHitPixVsEtapL5->GetXaxis()->GetNbins(),UnCorrHHitPixVsEtapL5->GetXaxis()->GetXmin(),UnCorrHHitPixVsEtapL5->GetXaxis()->GetXmax());
+TH1D* UnCorrStripVsEtaP5 = new TH1D("UnCorrStripVsEtaP5"       , "UnCorrStripVsEtaP5"      ,UnCorrHHitStripVsEtaP5->GetXaxis()->GetNbins(),UnCorrHHitStripVsEtaP5->GetXaxis()->GetXmin(),UnCorrHHitStripVsEtaP5->GetXaxis()->GetXmax());
+TH1D* UnCorrStripVsEtapL5 = new TH1D("UnCorrStripVsEtapL5"       , "UnCorrStripVsEtapL5"      ,UnCorrHHitStripVsEtapL5->GetXaxis()->GetNbins(),UnCorrHHitStripVsEtapL5->GetXaxis()->GetXmin(),UnCorrHHitStripVsEtapL5->GetXaxis()->GetXmax());
+
+MakeMyProfile(UnCorrHHitPixVsEtaP5,UnCorrPixVsEtaP5);
+MakeMyProfile(UnCorrHHitPixVsEtapL5, UnCorrPixVsEtapL5);
+MakeMyProfile(UnCorrHHitStripVsEtaP5, UnCorrStripVsEtaP5);
+MakeMyProfile(UnCorrHHitStripVsEtapL5, UnCorrStripVsEtapL5);
+
+UnCorrHHitPixVsP= (TH2D*)gROOT->FindObject("HHitPixVsPw");
+UnCorrHHitStripVsP= (TH2D*)gROOT->FindObject("HHitStripVsPw");
+TH1D* UnCorrPixVsP = new TH1D("UnCorrPixVsP5"       , "UnCorrPixVsP5"      ,UnCorrHHitPixVsP->GetXaxis()->GetNbins(),UnCorrHHitPixVsP->GetXaxis()->GetXmin(),UnCorrHHitPixVsP->GetXaxis()->GetXmax());
+TH1D* UnCorrStripVsP = new TH1D("UnCorrStripVsP5"       , "UnCorrStripVsP5"      ,UnCorrHHitStripVsP->GetXaxis()->GetNbins(),UnCorrHHitStripVsP->GetXaxis()->GetXmin(),UnCorrHHitStripVsP->GetXaxis()->GetXmax());
+MakeMyProfile(UnCorrHHitPixVsP,UnCorrPixVsP);
+MakeMyProfile(UnCorrHHitStripVsP,UnCorrStripVsP);
+UnCorrHHitPixVsPExt= (TH2D*)gROOT->FindObject("HHitPixVsPExtw");
+UnCorrHHitStripVsPExt= (TH2D*)gROOT->FindObject("HHitStripVsPExtw");
+TH1D* UnCorrPixVsPExt = new TH1D("UnCorrPixVsPExt"       , "UnCorrPixVsPExt"      ,UnCorrHHitPixVsPExt->GetXaxis()->GetNbins(),UnCorrHHitPixVsPExt->GetXaxis()->GetXmin(),UnCorrHHitPixVsPExt->GetXaxis()->GetXmax());
+TH1D* UnCorrStripVsPExt = new TH1D("UnCorrStripVsPExt"       , "UnCorrStripVsPExt"      ,UnCorrHHitStripVsPExt->GetXaxis()->GetNbins(),UnCorrHHitStripVsPExt->GetXaxis()->GetXmin(),UnCorrHHitStripVsPExt->GetXaxis()->GetXmax());
+MakeMyProfile(UnCorrHHitPixVsPExt,UnCorrPixVsPExt);
+MakeMyProfile(UnCorrHHitStripVsPExt,UnCorrStripVsPExt);
+
+cout <<  "fill from file1"<< endl;
+
+
+TCanvas *c5 = new TCanvas("c5", "EtaDep Corr", 800,600);
+c5->Divide(2,2);                       
+c5->cd(2);                       
+CorrHHitPixVsEtaP5->SetStats(kFALSE);
+CorrHHitPixVsEtaP5 ->Draw("colz");
+CorrPixVsEtaP5->Draw("same");
+TProfile* pr1 = CorrHHitPixVsEtaP5->ProfileX();
+pr1->SetLineColor(2);
+pr1->Draw("same");
+
+c5->cd(1);                       
+CorrHHitPixVsEtapL5->SetStats(kFALSE);
+CorrHHitPixVsEtapL5 ->Draw("colz");
+CorrPixVsEtapL5->Draw("same");
+TProfile* pr2 = CorrHHitPixVsEtapL5->ProfileX();
+pr2->SetLineColor(2);
+pr2->Draw("same");
+
+c5->cd(4);                       
+CorrHHitStripVsEtaP5->SetStats(kFALSE);
+CorrHHitStripVsEtaP5 ->Draw("colz");
+CorrStripVsEtaP5->Draw("same");
+TProfile* pr3 = CorrHHitStripVsEtaP5->ProfileX();
+pr3->SetLineColor(2);
+pr3->Draw("same");
+
+c5->cd(3);                       
+CorrHHitStripVsEtapL5->SetStats(kFALSE);
+CorrHHitStripVsEtapL5 ->Draw("colz");
+CorrStripVsEtapL5->Draw("same");
+TProfile* pr4 = CorrHHitStripVsEtapL5->ProfileX();
+pr4->SetLineColor(2);
+pr4->Draw("same");
+
+c5->cd();
+if (mb) c5->SaveAs("colorProfile_mb_corr.png");
+else c5->SaveAs("colorProfile_tt_corr.png");
+cout <<  "c5 ok"<< endl;
+
+TCanvas *c5b = new TCanvas("c5b", "EtaDep UnCorr", 800,600);
+c5b->Divide(2,2);                       
+c5b->cd(2);                       
+UnCorrHHitPixVsEtaP5->SetStats(kFALSE);
+UnCorrHHitPixVsEtaP5 ->Draw("colz");
+UnCorrPixVsEtaP5->Draw("same");
+pr1 = UnCorrHHitPixVsEtaP5->ProfileX();
+pr1->SetLineColor(2);
+pr1->Draw("same");
+
+c5b->cd(1);                       
+UnCorrHHitPixVsEtapL5->SetStats(kFALSE);
+UnCorrHHitPixVsEtapL5 ->Draw("colz");
+UnCorrPixVsEtapL5->Draw("same");
+pr2 = UnCorrHHitPixVsEtapL5->ProfileX();
+pr2->SetLineColor(2);
+pr2->Draw("same");
+
+c5b->cd(4);                       
+UnCorrHHitStripVsEtaP5->SetStats(kFALSE);
+UnCorrHHitStripVsEtaP5 ->Draw("colz");
+UnCorrStripVsEtaP5->Draw("same");
+pr3 = UnCorrHHitStripVsEtaP5->ProfileX();
+pr3->SetLineColor(2);
+pr3->Draw("same");
+
+c5b->cd(3);                       
+UnCorrHHitStripVsEtapL5->SetStats(kFALSE);
+UnCorrHHitStripVsEtapL5 ->Draw("colz");
+UnCorrStripVsEtapL5->Draw("same");
+pr4 = UnCorrHHitStripVsEtapL5->ProfileX();
+pr4->SetLineColor(2);
+pr4->Draw("same");
+
+c5b->cd();
+if (mb) c5b->SaveAs("colorProfile_mb_uncorr.png");
+else c5b->SaveAs("colorProfile_tt_uncorr.png");
+cout <<  "c5b ok"<< endl;
+
+
+TCanvas *c6 = new TCanvas("c6", "Corr EtaDep", 600,600);
+c6->cd();
+
+CorrPixVsEtaP5->SetLineColor(2);
+CorrPixVsEtapL5->SetLineColor(2);
+CorrStripVsEtaP5->SetLineColor(4);
+CorrStripVsEtapL5->SetLineColor(4);
+
+CorrPixVsEtaP5->SetMarkerColor(2);
+CorrPixVsEtapL5->SetMarkerColor(2);
+CorrStripVsEtaP5->SetMarkerColor(4);
+CorrStripVsEtapL5->SetMarkerColor(4);
+
+CorrPixVsEtaP5->SetMarkerStyle(21);
+CorrPixVsEtapL5->SetMarkerStyle(26);
+CorrStripVsEtaP5->SetMarkerStyle(21);
+CorrStripVsEtapL5->SetMarkerStyle(26);
+
+
+CorrPixVsEtaP5->SetStats(kFALSE);
+CorrPixVsEtaP5->SetMaximum(8);
+CorrPixVsEtaP5->SetMinimum(1);
+CorrPixVsEtaP5->Draw();
+CorrPixVsEtapL5->Draw("same");
+CorrStripVsEtaP5->Draw("same");
+CorrStripVsEtapL5->Draw("same");
+
+TLegend* qw3 =  new TLegend(0.15,0.12,0.40,0.28);
+TString type;
+if (mb) type=" (MB)";
+else type=" (tt)";
+
+qw3->AddEntry(CorrPixVsEtaP5,    "Pixel p>5"+type,                       "p");
+qw3->AddEntry(CorrPixVsEtapL5,   "Pixel p<5"+type,                       "p");
+qw3->AddEntry(CorrStripVsEtaP5,      "Strip p>5"+type,                       "p");
+qw3->AddEntry(CorrStripVsEtapL5,     "Strip p<5"+type,                       "p");
+qw3->Draw("same");
+
+if (mb) c6->SaveAs("corr_etadep_mb.png");
+else c6->SaveAs("corr_etadep_tt.png");
+
+TCanvas *c6b = new TCanvas("c6b", "UnCorr EtaDep", 600,600);
+c6b->cd();
+
+UnCorrPixVsEtaP5->SetLineColor(2);
+UnCorrPixVsEtapL5->SetLineColor(2);
+UnCorrStripVsEtaP5->SetLineColor(4);
+UnCorrStripVsEtapL5->SetLineColor(4);
+
+UnCorrPixVsEtaP5->SetMarkerColor(2);
+UnCorrPixVsEtapL5->SetMarkerColor(2);
+UnCorrStripVsEtaP5->SetMarkerColor(4);
+UnCorrStripVsEtapL5->SetMarkerColor(4);
+
+UnCorrPixVsEtaP5->SetMarkerStyle(21);
+UnCorrPixVsEtapL5->SetMarkerStyle(26);
+UnCorrStripVsEtaP5->SetMarkerStyle(21);
+UnCorrStripVsEtapL5->SetMarkerStyle(26);
+
+
+
+UnCorrPixVsEtaP5->SetStats(kFALSE);
+UnCorrPixVsEtaP5->SetMaximum(6);
+UnCorrPixVsEtaP5->SetMinimum(1);
+UnCorrPixVsEtaP5->Draw();
+UnCorrPixVsEtapL5->Draw("same");
+UnCorrStripVsEtaP5->Draw("same");
+UnCorrStripVsEtapL5->Draw("same");
+
+qw3->Draw("same");
+if (mb) c6b->SaveAs("uncorr_etadep_mb.png");
+else c6b->SaveAs("uncorr_etadep_tt.png");
+
+TCanvas *c7 = new TCanvas("c7", "Corr PDep", 600,600);
+c7->cd();
+
+CorrPixVsP->SetLineColor(2);
+CorrPixVsPExt->SetLineColor(2);
+CorrStripVsP->SetLineColor(4);
+CorrStripVsPExt->SetLineColor(4);
+
+CorrPixVsP->SetMarkerColor(2);
+CorrPixVsPExt->SetMarkerColor(2);
+CorrStripVsP->SetMarkerColor(4);
+CorrStripVsPExt->SetMarkerColor(4);
+
+CorrPixVsP->SetMarkerStyle(21);
+CorrPixVsPExt->SetMarkerStyle(26);
+CorrStripVsP->SetMarkerStyle(21);
+CorrStripVsPExt->SetMarkerStyle(26);
+
+CorrPixVsP->SetStats(kFALSE);
+CorrPixVsP->SetMaximum(6);
+CorrPixVsP->SetMinimum(1);
+CorrPixVsP->Draw();
+CorrPixVsPExt->Draw("same");
+CorrStripVsP->Draw("same");
+CorrStripVsPExt->Draw("same");
+TLegend* qw4 =  new TLegend(0.15,0.12,0.40,0.28);
+qw4->AddEntry(CorrPixVsP,    "Pixel |#eta|<0.4"+type,                       "p");
+qw4->AddEntry(CorrPixVsPExt,   "Pixel |#eta|>0.4"+type,                       "p");
+qw4->AddEntry(CorrStripVsP,      "Strip |#eta|<0.4"+type,                       "p");
+qw4->AddEntry(CorrStripVsPExt,     "Strip |#eta|>0.4"+type,                       "p");
+qw4->Draw("same");
+if (mb) c7->SaveAs("corr_pdepw_mb.png");
+else c7->SaveAs("corr_pdepw_tt.png");
+
+TCanvas *c7b = new TCanvas("c7b", "UnCorr PDep", 600,600);
+c7b->cd();
+
+UnCorrPixVsP->SetLineColor(2);
+UnCorrPixVsPExt->SetLineColor(2);
+UnCorrStripVsP->SetLineColor(4);
+UnCorrStripVsPExt->SetLineColor(4);
+
+UnCorrPixVsP->SetMarkerColor(2);
+UnCorrPixVsPExt->SetMarkerColor(2);
+UnCorrStripVsP->SetMarkerColor(4);
+UnCorrStripVsPExt->SetMarkerColor(4);
+
+UnCorrPixVsP->SetMarkerStyle(21);
+UnCorrPixVsPExt->SetMarkerStyle(26);
+UnCorrStripVsP->SetMarkerStyle(21);
+UnCorrStripVsPExt->SetMarkerStyle(26);
+
+UnCorrPixVsP->SetStats(kFALSE);
+UnCorrPixVsP->SetMaximum(6);
+UnCorrPixVsP->SetMinimum(1);
+UnCorrPixVsP->Draw();
+UnCorrPixVsPExt->Draw("same");
+UnCorrStripVsP->Draw("same");
+UnCorrStripVsPExt->Draw("same");
+qw4->Draw("same");
+if (mb) c7b->SaveAs("uncorr_pdepw_mb.png");
+else c7b->SaveAs("uncorr_pdepw_tt.png");
+
+
+
+}
+
+void MakeMyProfile(TH2D* input, TH1D* FitResult) 
+{
+	       TH2D* inputnew = (TH2D*)input->Clone("tempTH2D");
+
+
+	       for(int x=1;x<inputnew->GetXaxis()->GetNbins()+1;x++){
+		  double eta = inputnew->GetXaxis()->GetBinCenter(x);
+		  TH1D* Projection = (TH1D*)(inputnew->ProjectionY("proj",x,x))->Clone();
+                  cout << " x " << x << " = "  << eta << " integral " << Projection->Integral() << endl;
+		  if(Projection->Integral()<100) {
+		   FitResult->SetBinContent(x, 0.);
+		   FitResult->SetBinError  (x, 0.);
+                  } 
+                  else {
+   		   Projection->SetAxisRange(1.,8.,"X");
+		   Projection->Sumw2();
+		   Projection->Scale(1.0/Projection->Integral());
+
+
+		   TF1* mygaus = new TF1("mygaus","gaus", 5., 1.);
+		   Projection->Fit("mygaus","Q0 RME");
+		   double chiFromFit  = (mygaus->GetChisquare())/(mygaus->GetNDF());
+		   FitResult->SetBinContent(x, mygaus->GetParameter(1));
+		   FitResult->SetBinError  (x, mygaus->GetParError (1));
+                   cout << "      fit " << mygaus->GetParameter(1) << "  chi2 " << chiFromFit << endl;
+                   delete mygaus;
+
+/*
+
+                   float maxval=Projection->GetXaxis()->GetBinCenter(Projection->GetMaximumBin());
+                   float liminf = maxval -2;
+                   if (liminf<0) liminf=0;
+                   float limsup = maxval + 3;
+                   TF1* mylandau = new TF1("mylandau","[0]*TMath::Landau(x,[1],[2])",liminf, limsup);
+                   mylandau->SetParameters(1,maxval,0.3);
+                   mylandau->SetParLimits(0, 0.1, 1000000000.0);
+                   mylandau->SetParLimits(1, 0.0001, 100.0);
+                   mylandau->SetParLimits(2, 0.0001, 100.0);
+                   Projection->Fit("mylandau","Q 0 RME");
+                   FitResult->SetBinContent(x, mylandau->GetParameter(1));
+                   FitResult->SetBinError  (x, mylandau->GetParError (1));
+                   delete mylandau;
+
+*/
+
+
+                  }
+
+                  delete Projection;
+	       }
+
+               delete inputnew;
+               return FitResult;
+}
+
+
+//void GetSF(bool mb, bool corr) {
+void GetSF() {
+  TFile *_file0 ;
+  TFile *_file1 ;
+
+/*
+  if (mb)  {
+//   if(corr) _file0= TFile::Open("minbias_template_corr.root");
+//   else _file0 = TFile::Open("minbias_template_uncorr.root");
+//   if(corr) _file0= TFile::Open("minb3_template_corr.root");
+//   else _file0 = TFile::Open("minb3_template_uncorr.root");
+   if(corr) _file0= TFile::Open("mb_247_3_template_corr.root");
+   else _file0 = TFile::Open("mb_247_3_template_uncorr.root");
+  }
+  else {
+//   if(corr) _file0 = TFile::Open("ttbar_template_corr.root");
+//   else _file0 = TFile::Open("ttbar_template_uncorr.root");
+   if(corr) _file0 = TFile::Open("tt3_template_corr.root");
+   else _file0 = TFile::Open("tt3_template_uncorr.root");
+  }
+*/
+   TH2D*   HdedxVsP1;
+   TH2D*   HdedxVsP2;
+
+   bool mc_to_data=false;
+   bool mc_alone=false;
+   bool data_alone=false;
+   bool test_year=true;
+
+  if (mc_alone)  {
+     _file0 = TFile::Open("crab_Analysis_2018_AllBackground_CodeV43p3_v1.root");
+     _file0->GetObject("HSCParticleAnalyzer/BaseName/SF_HHit2DPix",HdedxVsP2);
+     _file0->GetObject("HSCParticleAnalyzer/BaseName/SF_HHit2DStrip",HdedxVsP1);
+  }
+  else if (data_alone) {
+//     _file0 = new TFile ("crab_Analysis_SingleMuon_Run2018_CodeV43p3_v1.root");  // 
+     _file0 = new TFile ("crab_Analysis_SingleMuon_Run2017_CodeV43p3_v1.root");  // 
+     _file0->GetObject("HSCParticleAnalyzer/BaseName/SF_HHit2DPix",HdedxVsP2);
+     _file0->GetObject("HSCParticleAnalyzer/BaseName/SF_HHit2DStrip",HdedxVsP1);
+  }
+  else if (mc_to_data)  {
+     _file0 = new TFile ("crab_Analysis_SingleMuon_Run2018_CodeV43p3_v1.root");
+     _file0->GetObject("HSCParticleAnalyzer/BaseName/SF_HHit2DStrip",HdedxVsP1);
+     _file1 = TFile::Open("crab_Analysis_2018_AllBackground_CodeV43p3_v1.root");
+     _file1->GetObject("HSCParticleAnalyzer/BaseName/SF_HHit2DStrip",HdedxVsP2);
+  }
+  else if (test_year)  {
+     _file0 = new TFile ("crab_Analysis_SingleMuon_Run2018_CodeV43p3_v1.root");
+     _file0->GetObject("HSCParticleAnalyzer/BaseName/SF_HHit2DStrip",HdedxVsP1);
+     _file1 = TFile::Open("crab_Analysis_SingleMuon_Run2017_CodeV43p3_v1.root");
+     _file1->GetObject("HSCParticleAnalyzer/BaseName/SF_HHit2DStrip",HdedxVsP2);
+  }
+
+
+   HdedxVsP2->Rebin2D(2,1);
+   HdedxVsP1->Rebin2D(2,1);
+    TCanvas* c0 = new TCanvas("c0", "c0", 600,600);
+   c0->Divide(2,1);
+   c0->cd(1);
+   HdedxVsP2->Draw("colz");
+   c0->cd(2);
+   HdedxVsP1->Draw("colz");
+   c0->cd();
+   cout << " 2Dhisto ok " << endl;
+
+   TH1D* HdedxVsPProfile1 = new TH1D("HdedxVsPProfile1"       , "HdedxVsPProfile1"      ,HdedxVsP1->GetXaxis()->GetNbins(),HdedxVsP1->GetXaxis()->GetXmin(),HdedxVsP1->GetXaxis()->GetXmax());
+   TH1D* HdedxVsPProfile2 = new TH1D("HdedxVsPProfile2"       , "HdedxVsPProfile2"      ,HdedxVsP2->GetXaxis()->GetNbins(),HdedxVsP2->GetXaxis()->GetXmin(),HdedxVsP2->GetXaxis()->GetXmax());
+
+   HdedxVsPProfile1->Rebin(2);
+   HdedxVsPProfile2->Rebin(2);
+
+
+   MakeMyProfile(HdedxVsP1, HdedxVsPProfile1);
+   MakeMyProfile(HdedxVsP2, HdedxVsPProfile2);
+   cout << " Profile ok " << endl;
+
+   //
+
+   double SFProfile;
+   std::string SaveDir = "SFdir";
+   FILE* fout = fopen ((SaveDir+"ScaleFactors.txt").c_str(), "w");
+   fprintf (fout, "=================\n >>> Old CCC >>>\n=================\n");
+
+   TH1D* Chi2Dist = new TH1D("Chi2Dist","Chi2Dist",5000, 0.8 ,1.8);
+
+   double Minimum = 99999999999;
+   double AbsGain = -1;
+
+   for(int i=1;i<=Chi2Dist->GetNbinsX();i++){
+      double ScaleFactor = Chi2Dist->GetXaxis()->GetBinCenter(i);
+      TH1D* Rescaled = (TH1D*)HdedxVsPProfile2->Clone("Cloned");
+      Rescaled->Scale(ScaleFactor);
+      double Dist = 0;
+      double Error = 0;
+      for(int x=1;x<=HdedxVsPProfile1->GetNbinsX();x++){
+         double Momentum = HdedxVsPProfile1->GetXaxis()->GetBinCenter(x);
+         if(Momentum<5)continue;  //|| Momentum>20)continue;
+         if(HdedxVsPProfile1->GetBinError(x)<=0)continue;
+         Dist += pow(HdedxVsPProfile1->GetBinContent(x) - Rescaled->GetBinContent(x),2) / std::max(1E-8,pow(HdedxVsPProfile1->GetBinError(x),2));
+         Error += pow(HdedxVsPProfile1->GetBinError(x),2);
+      }
+      Dist *= Error;
+
+      if(Dist<Minimum){Minimum=Dist;AbsGain=ScaleFactor;}
+
+      //std::cout << "Rescale = " << ScaleFactor << " --> SquareDist = " << Dist << endl;
+      Chi2Dist->Fill(ScaleFactor,Dist);
+      delete Rescaled;
+   }
+
+   std::cout << "SCALE FACTOR WITH PROFILE = " << AbsGain << endl;
+   SFProfile = AbsGain;
+
+    TCanvas* c1 = new TCanvas("c1", "c1", 600,600);
+   Chi2Dist->SetStats(kFALSE);
+   Chi2Dist->GetXaxis()->SetNdivisions(504);
+   Chi2Dist->GetXaxis()->SetTitle("Rescale Factor");
+   Chi2Dist->GetYaxis()->SetTitle("Weighted Square Distance");
+   Chi2Dist->Draw("");
+   c1->SetLogy(true);
+   c1->SetGridx(true); 
+   SaveCanvas(c1, SaveDir, "Rescale_Chi2Dist");
+
+   TCanvas* c2 = new TCanvas("c2", "c2", 600,600);
+   TLegend* leg = new TLegend (0.25, 0.70, 0.65, 0.90);
+   leg->SetHeader ("Fitting the Gaussian means");
+   leg->SetFillColor(0);
+   leg->SetFillStyle(0);
+   leg->SetBorderSize(0);
+   HdedxVsPProfile1->SetStats(kFALSE);
+   HdedxVsPProfile1->SetAxisRange(5,50,"X");
+   HdedxVsPProfile1->SetAxisRange(0.0,10.,"Y");
+   HdedxVsPProfile1->GetXaxis()->SetTitle("track momentum (GeV)");
+   HdedxVsPProfile1->GetYaxis()->SetTitle("dE/dx (MeV/cm)");
+   HdedxVsPProfile1->SetMarkerColor(2);
+   HdedxVsPProfile1->SetLineColor(2);
+   HdedxVsPProfile1->SetLineWidth(2);
+   HdedxVsPProfile1->Draw("");
+
+   HdedxVsPProfile2->SetMarkerColor(1);
+   HdedxVsPProfile2->Draw("same");
+   TH1D* HdedxVsPProfile4 = (TH1D*)HdedxVsPProfile2->Clone("afs");
+   HdedxVsPProfile4->SetMarkerColor(4);
+   HdedxVsPProfile4->SetLineColor(4);
+   HdedxVsPProfile4->Scale(AbsGain);
+   HdedxVsPProfile4->Draw("same");
+   if (data_alone || mc_alone) { 
+   leg->AddEntry (HdedxVsPProfile1, "Strip", "LP");
+   leg->AddEntry (HdedxVsPProfile2, "unscaled Pixel", "LP");
+   leg->AddEntry (HdedxVsPProfile4, "scaled Pixel",   "LP");
+   }
+   else if (mc_to_data) {
+   leg->AddEntry (HdedxVsPProfile1, "Data Strip ", "LP");
+   leg->AddEntry (HdedxVsPProfile2, "unscaled MC Pixel", "LP");
+   leg->AddEntry (HdedxVsPProfile4, "scaled MC Pixel",   "LP");
+   }
+   leg->Draw();
+
+//   DrawPreliminary("", 13, "");
+   SaveCanvas(c2, SaveDir, "Rescale_HdedxVsPProfile");
+
+   if (data_alone || mc_alone) fprintf (fout, "HHit Pixel to Strip ::  Profile: %.7lf \n", SFProfile);
+   else if (mc_to_data)  fprintf (fout, "HHit MC to Data Strip ::  Profile: %.7lf \n", SFProfile);
+   fclose (fout);
+
+}
+
+
+void SaveCanvas(TCanvas* c, std::string path, std::string name, bool OnlyPPNG){
+   std::string tmppath = path;
+   if(tmppath[tmppath.length()-1]!='/')tmppath += "_";
+   tmppath += name;
+
+   std::string filepath;
+   filepath = tmppath + ".png"; c->SaveAs(filepath.c_str()); if(OnlyPPNG)return;
+   filepath = tmppath +  ".eps"; c->SaveAs(filepath.c_str());
+   filepath = tmppath + ".C"  ; c->SaveAs(filepath.c_str());
+   filepath = tmppath +  ".pdf"; c->SaveAs(filepath.c_str());
+}

--- a/Analyzer/test/CalibMacros/stability2.C
+++ b/Analyzer/test/CalibMacros/stability2.C
@@ -1,0 +1,1283 @@
+#include "../tdrstyle.C"
+#include <TH2.h>
+#include <TStyle.h>
+#include <TCanvas.h>
+#include "TH1D.h"
+#include "TMultiGraph.h"
+#include "TGraph.h"
+#include "TCanvas.h"
+#include <iostream>
+#include <fstream>
+#include <iomanip>
+#include "THStack.h"
+#include "TFile.h"
+#include "TROOT.h"
+#include "TColor.h"
+#include "TF1.h"
+#include "TMath.h"
+#include <TLegend.h>
+#include <TProfile.h>
+#include <TLatex.h>
+#include <TAxis.h>
+#include <TProfile.h>
+#include <TString.h>
+#include "Math/Vavilov.h"
+#include "Math/VavilovAccurate.h"
+
+bool check=false;
+int which_check=1;
+
+using namespace std;
+
+struct Vavilov_Func {
+   Vavilov_Func() {}
+
+   double operator() (const double *x, const double *p) {
+      double kappa = p[0];
+      double beta2 = p[1];
+      // float xvav = (qtotal-mpv)/sigmaQ;
+      return p[4]*( pdf.Pdf( (x[0]-p[2])/p[3], kappa,beta2) );
+   }
+   
+   ROOT::Math::VavilovAccurate pdf;
+};
+
+TH1D* extractMaximum(TH2D* histo2d);
+TH1D* extractMaximum(TH2D* histo2d, TString namehist);
+TH1D* extractRMS(TH2D* histo2d, TString namehist);
+TH1D* extractLandau(TH2D* histo2d, TString namehist);
+TH1D* extractGaus(TH2D* histo2d, TString namehist);
+TH1D* extractVavilov(TH2D* histo2d, TString namehist);
+TH1D* extractQuantile(TH2D* histo2d, TString namehist, int caseQ);
+TH1D* extractVariationGaus(TH2D* histo2d, TString namehist, int nbin, float x1, float x2);
+TH1D* extractVariationMaximum(TH2D* histo2d, TString namehist , int nbin, float x1, float x2);
+
+TH1D* extractDiff(TFile* file1, TFile* file2, TString namehistin, TString namehistout);
+TH2D* modif2DHisto(TH2D* histo, TString namehist);
+TH2D* correl2DHisto(TH1D* histo1, TH1D* histo2, TString namehist, TString namecap);
+
+void stability(){
+
+int caseFit2=2;
+bool full=false;   // Charge Pixel in 0-20 or in 0-4.5 
+//TFile *myfile = TFile::Open("crab_Analysis_SingleMuon_CodeV42p6_v1.root"); // 12jan23
+TFile *myfile = TFile::Open("crab_Analysis_SingleMuon_CodeV43p3_v1.root"); //16feb23
+
+TCanvas *c1 = new TCanvas("Ih", "Ih",10,32,782,552);
+    c1->SetFillColor(10);
+    c1->SetBorderMode(0);
+    c1->SetBorderSize(2);
+    c1->SetFrameFillColor(0);
+    c1->SetFrameBorderMode(0);
+    c1->cd();
+    gStyle->SetOptTitle(0);
+    gStyle->SetOptStat(0);
+
+TH1D* LdEdXVsRun;
+TH1D* LdEdXVsRunSel;
+TH1D* LdEdXVsRun2;
+TH1D* LdEdXVsRunSel2;
+
+// GAUS 
+
+TH2D* dEdX0NoL1VsRun;
+myfile->GetObject("HSCParticleAnalyzer/BaseName/Stab_Ih_NoL1_VsRun",dEdX0NoL1VsRun);
+
+ LdEdXVsRun = extractGaus(dEdX0NoL1VsRun,"LdEdXVsRun");
+
+ LdEdXVsRun->SetMarkerColor(2);
+ LdEdXVsRun->SetLineColor(2);
+
+ LdEdXVsRun->SetMinimum(3.);
+ LdEdXVsRun->SetMaximum(3.7);
+ LdEdXVsRun->GetXaxis()->SetRangeUser(295000, 325500);
+ LdEdXVsRun->GetXaxis()->SetTitle("Run number");
+ LdEdXVsRun->GetYaxis()->SetTitle("#mu(Ih per bin)");
+ LdEdXVsRun->Draw();
+
+ c1->SaveAs("Stab_IhNoL1_Gauss.pdf");
+
+
+TCanvas *c1_b = new TCanvas("Ias", "Ias",10,32,782,552);
+    c1_b->SetFillColor(10);
+    c1_b->SetBorderMode(0);
+    c1_b->SetBorderSize(2);
+    c1_b->SetFrameFillColor(0);
+    c1_b->SetFrameBorderMode(0);
+    c1_b->SetLeftMargin(0.15);
+    c1_b->cd();
+    gStyle->SetOptTitle(0);
+    gStyle->SetOptStat(0);
+
+
+TH2D* iasStripVsRun;
+myfile->GetObject("HSCParticleAnalyzer/BaseName/Stab_Gi_strip_VsRun",iasStripVsRun);
+TH1D* Lias = extractMaximum(iasStripVsRun,"Lias");
+
+Lias->SetMarkerColor(2);
+Lias->SetLineColor(2);
+
+Lias->SetMinimum(0.02);
+Lias->SetMaximum(0.025);
+Lias->GetXaxis()->SetRangeUser(295000, 325500);
+ Lias->GetXaxis()->SetTitle("Run number");
+ 
+ Lias->GetYaxis()->SetTitleOffset(1.5);
+ Lias->GetYaxis()->SetTitle("<G per bin>");
+Lias->Draw();
+c1_b->SaveAs("Stab_Ias_Mean.pdf");
+
+
+//----
+//
+
+
+
+TCanvas *c1_c = new TCanvas("ProbQ", "ProbQ",10,32,782,552);
+    c1_c->SetFillColor(10);
+    c1_c->SetBorderMode(0);
+    c1_c->SetBorderSize(2);
+    c1_c->SetFrameFillColor(0);
+    c1_c->SetFrameBorderMode(0);
+    c1_c->cd();
+    gStyle->SetOptTitle(0);
+    gStyle->SetOptStat(0);
+
+TH2D* InvprobQNoL1VsRunCut;
+myfile->GetObject("HSCParticleAnalyzer/BaseName/Stab_Fi_pixNoL1_VsRun",InvprobQNoL1VsRunCut);
+TH1D* Lprobq = extractMaximum(InvprobQNoL1VsRunCut,"Lprobq");
+
+
+Lprobq->SetMarkerColor(2);
+Lprobq->SetLineColor(2);
+
+
+
+Lprobq->SetMinimum(0.6);
+Lprobq->SetMaximum(0.7);
+Lprobq->GetXaxis()->SetRangeUser(295000, 325500);
+ Lprobq->GetXaxis()->SetTitle("Run number");
+ Lprobq->GetYaxis()->SetTitleOffset(1.2);
+ Lprobq->GetYaxis()->SetTitle("<F per bin>");
+Lprobq->Draw();
+c1_c->SaveAs("Stab_ProbQ_Mean.pdf");
+
+TCanvas *c2 = new TCanvas("InvB", "InvB",10,32,782,552);
+c2->SetFillColor(10);
+c2->SetBorderMode(0);
+c2->SetBorderSize(2);
+c2->SetFrameFillColor(0);
+c2->SetFrameBorderMode(0);
+c2->cd();
+gStyle->SetOptStat(0);
+
+
+TH2D* invBVsRun;
+myfile->GetObject("HSCParticleAnalyzer/BaseName/Stab_invB_VsRun",invBVsRun);
+TH1D* LinvBVsRun = extractGaus(invBVsRun,"LinvBVsRun");
+
+LinvBVsRun->SetMarkerColor(2);
+LinvBVsRun->SetLineColor(2);
+
+LinvBVsRun->SetMinimum(0.5);
+LinvBVsRun->SetMaximum(1.5);
+LinvBVsRun->GetXaxis()->SetRangeUser(295000, 325500);
+LinvBVsRun->Draw();
+
+//c2->SaveAs("Stab_invBeta_Gauss.pdf");
+
+
+TCanvas *c3 = new TCanvas("Ih1D", "Ih",10,32,782,552);
+    c3->SetFillColor(10);
+    c3->SetBorderMode(0);
+    c3->SetBorderSize(2);
+    c3->SetFrameFillColor(0);
+    c3->SetFrameBorderMode(0);
+    c3->cd();
+    gStyle->SetOptTitle(0);
+    gStyle->SetOptStat(1);
+
+TH1D* L1DdEdXVsRun;
+TH1D* L1DdEdXVsRunSel;
+
+// GAUS 
+
+ L1DdEdXVsRun = extractVariationGaus(dEdX0NoL1VsRun,"L1DdEdXVsRun",100,3.1,3.4);
+
+ L1DdEdXVsRun->SetMarkerColor(2);
+ L1DdEdXVsRun->SetLineColor(2);
+ L1DdEdXVsRun->GetXaxis()->SetTitle("weigthed #mu(Ih)");
+
+ L1DdEdXVsRun->Draw("hist");
+
+ c3->SaveAs("Stab1D_IhNoL1_Gauss.pdf");
+
+
+
+
+//
+//---
+
+
+TCanvas *c3_b = new TCanvas("Ias1D", "Ias",10,32,782,552);
+    c3_b->SetFillColor(10);
+    c3_b->SetBorderMode(0);
+    c3_b->SetBorderSize(2);
+    c3_b->SetFrameFillColor(0);
+    c3_b->SetFrameBorderMode(0);
+    c3_b->cd();
+    gStyle->SetOptTitle(0);
+    gStyle->SetOptStat(1);
+
+TH1D* L1Dias = extractVariationMaximum(iasStripVsRun,"L1Dias",100,0.02,0.025);
+
+
+L1Dias->SetMarkerColor(2);
+L1Dias->SetLineColor(2);
+
+
+
+L1Dias->GetXaxis()->SetTitle("weigthed <G>");
+L1Dias->Draw("hist");
+c3_b->SaveAs("Stab1D_Ias_Mean.pdf");
+
+
+//----
+//
+
+
+
+TCanvas *c3_c = new TCanvas("ProbQ1D", "ProbQ",10,32,782,552);
+    c3_c->SetFillColor(10);
+    c3_c->SetBorderMode(0);
+    c3_c->SetBorderSize(2);
+    c3_c->SetFrameFillColor(0);
+    c3_c->SetFrameBorderMode(0);
+    c3_c->cd();
+    gStyle->SetOptTitle(0);
+    gStyle->SetOptStat(1);
+
+TH1D* L1Dprobq = extractVariationMaximum(InvprobQNoL1VsRunCut,"L1Dprobq",100,0.6, 0.7);
+
+
+L1Dprobq->SetMarkerColor(2);
+L1Dprobq->SetLineColor(2);
+
+
+
+L1Dprobq->GetXaxis()->SetTitle("weigthed <F>");
+L1Dprobq->Draw("hist" );
+c3_c->SaveAs("Stab1D_ProbQ_Mean.pdf");
+
+}
+
+void plotDiff(){
+
+TFile * file1 = TFile::Open("/opt/sbg/cms/safe1/cms/ccollard/HSCP/CMSSW_10_6_2/src/stage/ntuple/test/analysisRun2/analysis_full.root");
+TFile * file2 = TFile::Open("analysis_ul.root");
+
+TCanvas *c1 = new TCanvas("Ih", "Ih",10,32,782,552);
+    c1->SetFillColor(10);
+    c1->SetBorderMode(0);
+    c1->SetBorderSize(2);
+    c1->SetFrameFillColor(0);
+    c1->SetFrameBorderMode(0);
+    c1->cd();
+    gStyle->SetOptTitle(0);
+    gStyle->SetOptStat(0);
+
+TH1D* LdEdXVsRun = extractDiff(file1, file2,  "dEdXVsRun", "LdEdXVsRun");
+TH1D* LdEdXpixVsRun = extractDiff(file1, file2,  "dEdXpixVsRun","LdEdXpixVsRun");
+TH1D* LdEdXstripVsRun = extractDiff(file1, file2,  "dEdXstripVsRun","LdEdXstripVsRun");
+
+LdEdXpixVsRun->SetMarkerColor(2);
+LdEdXpixVsRun->SetLineColor(2);
+LdEdXstripVsRun->SetMarkerColor(8);
+LdEdXstripVsRun->SetLineColor(8);
+
+LdEdXVsRun->SetMinimum(-1.);
+LdEdXVsRun->SetMaximum(1.);
+LdEdXVsRun->Draw();
+LdEdXpixVsRun->Draw("same");
+LdEdXstripVsRun->Draw("same");
+
+c1->SaveAs("Ih.pdf");
+//
+//----
+//
+
+TCanvas *c0 = new TCanvas("Ih_0", "Ih_0",10,32,782,552);
+c0->SetFillColor(10);
+c0->SetBorderMode(0);
+c0->SetBorderSize(2);
+c0->SetFrameFillColor(0);
+c0->SetFrameBorderMode(0);
+c0->cd();
+gStyle->SetOptTitle(0);
+gStyle->SetOptStat(0);
+
+TH1D* LdEdX0VsRun = extractDiff(file1, file2,  "dEdX0VsRun", "LdEdX0VsRun");
+TH1D* LdEdX0pixVsRun = extractDiff(file1, file2,  "dEdX0pixVsRun","LdEdX0pixVsRun");
+TH1D* LdEdX0stripVsRun = extractDiff(file1, file2,  "dEdX0stripVsRun","LdEdX0stripVsRun");
+
+LdEdX0pixVsRun->SetMarkerColor(2);
+LdEdX0pixVsRun->SetLineColor(2);
+LdEdX0stripVsRun->SetMarkerColor(8);
+LdEdX0stripVsRun->SetLineColor(8);
+
+LdEdX0VsRun->SetMinimum(-1.);
+LdEdX0VsRun->SetMaximum(1.);
+LdEdX0VsRun->Draw();
+LdEdX0pixVsRun->Draw("same");
+LdEdX0stripVsRun->Draw("same");
+c0->SaveAs("Ih_0.pdf");
+
+TCanvas *c11 = new TCanvas("Ih_4", "Ih_4",10,32,782,552);
+    c11->SetFillColor(10);
+    c11->SetBorderMode(0);
+    c11->SetBorderSize(2);
+    c11->SetFrameFillColor(0);
+    c11->SetFrameBorderMode(0);
+    c11->cd();
+    gStyle->SetOptTitle(0);
+    gStyle->SetOptStat(0);
+
+TH1D* LdEdX4VsRun = extractDiff(file1, file2,"dEdXV4sRun","LdEdX4VsRun");
+TH1D* LdEdX4pixVsRun = extractDiff(file1, file2,"dEdX4pixVsRun","LdEdX4pixVsRun");
+TH1D* LdEdX4stripVsRun = extractDiff(file1, file2,"dEdX4stripVsRun","LdEdX4stripVsRun");
+
+LdEdX4pixVsRun->SetMarkerColor(2);
+LdEdX4pixVsRun->SetLineColor(2);
+LdEdX4stripVsRun->SetMarkerColor(8);
+LdEdX4stripVsRun->SetLineColor(8);
+
+LdEdX4VsRun->SetMinimum(-1.);
+LdEdX4VsRun->SetMaximum(1.);
+LdEdX4VsRun->Draw();
+LdEdX4pixVsRun->Draw("same");
+LdEdX4stripVsRun->Draw("same");
+
+//
+//----
+//
+
+TCanvas *c01 = new TCanvas("Ih_40", "Ih_40",10,32,782,552);
+c01->SetFillColor(10);
+c01->SetBorderMode(0);
+c01->SetBorderSize(2);
+c01->SetFrameFillColor(0);
+c01->SetFrameBorderMode(0);
+c01->cd();
+gStyle->SetOptTitle(0);
+gStyle->SetOptStat(0);
+
+TH1D* LdEdX40VsRun = extractDiff(file1, file2,"dEdX40VsRun","LdEdX40VsRun");
+TH1D* LdEdX40pixVsRun = extractDiff(file1, file2,"dEdX40pixVsRun","LdEdX40pixVsRun");
+TH1D* LdEdX40stripVsRun = extractDiff(file1, file2,"dEdX40stripVsRun","LdEdX40stripVsRun");
+
+LdEdX40pixVsRun->SetMarkerColor(2);
+LdEdX40pixVsRun->SetLineColor(2);
+LdEdX40stripVsRun->SetMarkerColor(8);
+LdEdX40stripVsRun->SetLineColor(8);
+
+LdEdX40VsRun->SetMinimum(-1.);
+LdEdX40VsRun->SetMaximum(1.);
+LdEdX40VsRun->Draw();
+LdEdX40pixVsRun->Draw("same");
+LdEdX40stripVsRun->Draw("same");
+
+//
+//----
+//
+
+TCanvas *c2 = new TCanvas("InvB", "InvB",10,32,782,552);
+c2->SetFillColor(10);
+c2->SetBorderMode(0);
+c2->SetBorderSize(2);
+c2->SetFrameFillColor(0);
+c2->SetFrameBorderMode(0);
+c2->cd();
+gStyle->SetOptStat(0);
+
+
+TH1D* LinvBVsRun = extractDiff(file1, file2,"invBVsRun","LinvBVsRun");
+TH1D* LinvBDTVsRun = extractDiff(file1, file2,"invBDTVsRun","LinvBDTVsRun");
+TH1D* LinvBCSCVsRun = extractDiff(file1, file2,"invBCSCVsRun","LinvBCSCVsRun");
+
+LinvBDTVsRun->SetMarkerColor(2);
+LinvBDTVsRun->SetLineColor(2);
+LinvBCSCVsRun->SetMarkerColor(8);
+LinvBCSCVsRun->SetLineColor(8);
+
+LinvBVsRun->SetMinimum(-1.);
+LinvBVsRun->SetMaximum(1.);
+LinvBVsRun->Draw();
+LinvBDTVsRun->Draw("same");
+LinvBCSCVsRun->Draw("same");
+
+
+//
+//----
+//
+
+//
+//----
+//
+
+TCanvas *cChargPix = new TCanvas("ChargPix", "ChargPix",10,32,782,552);
+cChargPix->SetFillColor(10);
+cChargPix->SetBorderMode(0);
+cChargPix->SetBorderSize(2);
+cChargPix->SetFrameFillColor(0);
+cChargPix->SetFrameBorderMode(0);
+cChargPix->cd();
+gStyle->SetOptTitle(0);
+gStyle->SetOptStat(0);
+
+TH1D* LZooChargeVsRun_pixl1 = extractDiff(file1, file2,"ZooChargeVsRun_pixl1","LZooChargeVsRun_pixl1");
+TH1D* LZooChargeVsRun_pixl2 = extractDiff(file1, file2,"ZooChargeVsRun_pixl2","LZooChargeVsRun_pixl2");
+TH1D* LZooChargeVsRun_pixl3 = extractDiff(file1, file2,"ZooChargeVsRun_pixl3","LZooChargeVsRun_pixl3");
+TH1D* LZooChargeVsRun_pixl4 = extractDiff(file1, file2,"ZooChargeVsRun_pixl4","LZooChargeVsRun_pixl4");
+
+LZooChargeVsRun_pixl2->SetMarkerColor(2);
+LZooChargeVsRun_pixl2->SetLineColor(2);
+LZooChargeVsRun_pixl3->SetMarkerColor(8);
+LZooChargeVsRun_pixl3->SetLineColor(8);
+LZooChargeVsRun_pixl4->SetMarkerColor(4);
+LZooChargeVsRun_pixl4->SetLineColor(4);
+
+LZooChargeVsRun_pixl1->SetMinimum(-1.);
+LZooChargeVsRun_pixl1->SetMaximum(1.);
+LZooChargeVsRun_pixl1->Draw();
+LZooChargeVsRun_pixl2->Draw("same");
+LZooChargeVsRun_pixl3->Draw("same");
+LZooChargeVsRun_pixl4->Draw("same");
+
+cChargPix->SaveAs("ChargPix.pdf");
+//
+//--
+//
+
+TCanvas *cChargDisk = new TCanvas("ChargDisk", "ChargDisk",10,32,782,552);
+cChargDisk->SetFillColor(10);
+cChargDisk->SetBorderMode(0);
+cChargDisk->SetBorderSize(2);
+cChargDisk->SetFrameFillColor(0);
+cChargDisk->SetFrameBorderMode(0);
+cChargDisk->cd();
+gStyle->SetOptTitle(0);
+gStyle->SetOptStat(0);
+
+TH1D* LZooChargeVsRun_pixd1 = extractDiff(file1, file2,"ZooChargeVsRun_pixd1","LZooChargeVsRun_pixd1");
+TH1D* LZooChargeVsRun_pixd2 = extractDiff(file1, file2,"ZooChargeVsRun_pixd2","LZooChargeVsRun_pixd2");
+TH1D* LZooChargeVsRun_pixd3 = extractDiff(file1, file2,"ZooChargeVsRun_pixd3","LZooChargeVsRun_pixd3");
+
+LZooChargeVsRun_pixd2->SetMarkerColor(2);
+LZooChargeVsRun_pixd2->SetLineColor(2);
+LZooChargeVsRun_pixd3->SetMarkerColor(8);
+LZooChargeVsRun_pixd3->SetLineColor(8);
+
+LZooChargeVsRun_pixd1->SetMinimum(-1.);
+LZooChargeVsRun_pixd1->SetMaximum(1.);
+LZooChargeVsRun_pixd1->Draw();
+LZooChargeVsRun_pixd2->Draw("same");
+LZooChargeVsRun_pixd3->Draw("same");
+cChargDisk->SaveAs("ChargDisk.pdf");
+
+//
+//--
+//
+
+TCanvas *cChargTib = new TCanvas("ChargTib", "ChargTib",10,32,782,552);
+cChargTib->SetFillColor(10);
+cChargTib->SetBorderMode(0);
+cChargTib->SetBorderSize(2);
+cChargTib->SetFrameFillColor(0);
+cChargTib->SetFrameBorderMode(0);
+cChargTib->cd();
+gStyle->SetOptTitle(0);
+gStyle->SetOptStat(0);
+
+TH1D* LZooChargeVsRun_tib1 = extractDiff(file1, file2,"ZooChargeVsRun_tib1","LZooChargeVsRun_tib1");
+TH1D* LZooChargeVsRun_tib2 = extractDiff(file1, file2,"ZooChargeVsRun_tib2","LZooChargeVsRun_tib2");
+TH1D* LZooChargeVsRun_tib3 = extractDiff(file1, file2,"ZooChargeVsRun_tib3","LZooChargeVsRun_tib3");
+TH1D* LZooChargeVsRun_tib4 = extractDiff(file1, file2,"ZooChargeVsRun_tib4","LZooChargeVsRun_tib4");
+
+LZooChargeVsRun_tib2->SetMarkerColor(2);
+LZooChargeVsRun_tib2->SetLineColor(2);
+LZooChargeVsRun_tib3->SetMarkerColor(8);
+LZooChargeVsRun_tib3->SetLineColor(8);
+LZooChargeVsRun_tib4->SetMarkerColor(4);
+LZooChargeVsRun_tib4->SetLineColor(4);
+
+LZooChargeVsRun_tib1->SetMinimum(-1.);
+LZooChargeVsRun_tib1->SetMaximum(1.);
+LZooChargeVsRun_tib1->Draw();
+LZooChargeVsRun_tib2->Draw("same");
+LZooChargeVsRun_tib3->Draw("same");
+LZooChargeVsRun_tib4->Draw("same");
+
+cChargTib->SaveAs("ChargTib.pdf");
+//
+//--
+//
+
+TCanvas *cChargTob = new TCanvas("ChargTob", "ChargTob",10,32,782,552);
+cChargTob->SetFillColor(10);
+cChargTob->SetBorderMode(0);
+cChargTob->SetBorderSize(2);
+cChargTob->SetFrameFillColor(0);
+cChargTob->SetFrameBorderMode(0);
+cChargTob->cd();
+gStyle->SetOptTitle(0);
+gStyle->SetOptStat(0);
+
+TH1D* LZooChargeVsRun_tob1 = extractDiff(file1, file2,"ZooChargeVsRun_tob1","LZooChargeVsRun_tob1");
+TH1D* LZooChargeVsRun_tob2 = extractDiff(file1, file2,"ZooChargeVsRun_tob2","LZooChargeVsRun_tob2");
+
+LZooChargeVsRun_tob2->SetMarkerColor(2);
+LZooChargeVsRun_tob2->SetLineColor(2);
+
+LZooChargeVsRun_tob1->SetMinimum(-1.);
+LZooChargeVsRun_tob1->SetMaximum(1.);
+LZooChargeVsRun_tob1->Draw();
+LZooChargeVsRun_tob2->Draw("same");
+cChargTob->SaveAs("ChargTob.pdf");
+
+//
+//--
+//
+
+TCanvas *cChargTid = new TCanvas("ChargTid", "ChargTid",10,32,782,552);
+cChargTid->SetFillColor(10);
+cChargTid->SetBorderMode(0);
+cChargTid->SetBorderSize(2);
+cChargTid->SetFrameFillColor(0);
+cChargTid->SetFrameBorderMode(0);
+cChargTid->cd();
+gStyle->SetOptTitle(0);
+gStyle->SetOptStat(0);
+
+TH1D* LZooChargeVsRun_tid1 = extractDiff(file1, file2,"ZooChargeVsRun_tid1","LZooChargeVsRun_tid1");
+TH1D* LZooChargeVsRun_tid2 = extractDiff(file1, file2,"ZooChargeVsRun_tid2","LZooChargeVsRun_tid2");
+TH1D* LZooChargeVsRun_tid3 = extractDiff(file1, file2,"ZooChargeVsRun_tid3","LZooChargeVsRun_tid3");
+TH1D* LZooChargeVsRun_tid4 = extractDiff(file1, file2,"ZooChargeVsRun_tid4","LZooChargeVsRun_tid4");
+TH1D* LZooChargeVsRun_tid5 = extractDiff(file1, file2,"ZooChargeVsRun_tid5","LZooChargeVsRun_tid5");
+TH1D* LZooChargeVsRun_tid6 = extractDiff(file1, file2,"ZooChargeVsRun_tid6","LZooChargeVsRun_tid6");
+
+LZooChargeVsRun_tid2->SetMarkerColor(2);
+LZooChargeVsRun_tid2->SetLineColor(2);
+LZooChargeVsRun_tid3->SetMarkerColor(8);
+LZooChargeVsRun_tid3->SetLineColor(8);
+LZooChargeVsRun_tid4->SetMarkerColor(4);
+LZooChargeVsRun_tid4->SetLineColor(4);
+LZooChargeVsRun_tid5->SetMarkerColor(6);
+LZooChargeVsRun_tid5->SetLineColor(6);
+LZooChargeVsRun_tid6->SetMarkerColor(13);
+LZooChargeVsRun_tid6->SetLineColor(13);
+
+LZooChargeVsRun_tid1->SetMinimum(-1.);
+LZooChargeVsRun_tid1->SetMaximum(1.);
+LZooChargeVsRun_tid1->Draw();
+LZooChargeVsRun_tid2->Draw("same");
+LZooChargeVsRun_tid3->Draw("same");
+LZooChargeVsRun_tid4->Draw("same");
+LZooChargeVsRun_tid5->Draw("same");
+LZooChargeVsRun_tid6->Draw("same");
+cChargTid->SaveAs("ChargTid.pdf");
+
+
+//
+//--
+//
+
+TCanvas *cChargTec = new TCanvas("ChargTec", "ChargTec",10,32,782,552);
+cChargTec->SetFillColor(10);
+cChargTec->SetBorderMode(0);
+cChargTec->SetBorderSize(2);
+cChargTec->SetFrameFillColor(0);
+cChargTec->SetFrameBorderMode(0);
+cChargTec->cd();
+gStyle->SetOptTitle(0);
+gStyle->SetOptStat(0);
+
+TH1D* LZooChargeVsRun_tec1 = extractDiff(file1, file2,"ZooChargeVsRun_tec1","LZooChargeVsRun_tec1");
+TH1D* LZooChargeVsRun_tec2 = extractDiff(file1, file2,"ZooChargeVsRun_tec2","LZooChargeVsRun_tec2");
+TH1D* LZooChargeVsRun_tec3 = extractDiff(file1, file2,"ZooChargeVsRun_tec3","LZooChargeVsRun_tec3");
+TH1D* LZooChargeVsRun_tec4 = extractDiff(file1, file2,"ZooChargeVsRun_tec4","LZooChargeVsRun_tec4");
+TH1D* LZooChargeVsRun_tec5 = extractDiff(file1, file2,"ZooChargeVsRun_tec5","LZooChargeVsRun_tec5");
+TH1D* LZooChargeVsRun_tec6 = extractDiff(file1, file2,"ZooChargeVsRun_tec6","LZooChargeVsRun_tec6");
+TH1D* LZooChargeVsRun_tec7 = extractDiff(file1, file2,"ZooChargeVsRun_tec7","LZooChargeVsRun_tec7");
+TH1D* LZooChargeVsRun_tec8 = extractDiff(file1, file2,"ZooChargeVsRun_tec8","LZooChargeVsRun_tec8");
+TH1D* LZooChargeVsRun_tec9 = extractDiff(file1, file2,"ZooChargeVsRun_tec9","LZooChargeVsRun_tec9");
+
+LZooChargeVsRun_tec2->SetMarkerColor(2);
+LZooChargeVsRun_tec2->SetLineColor(2);
+LZooChargeVsRun_tec3->SetMarkerColor(8);
+LZooChargeVsRun_tec3->SetLineColor(8);
+LZooChargeVsRun_tec4->SetMarkerColor(4);
+LZooChargeVsRun_tec4->SetLineColor(4);
+LZooChargeVsRun_tec5->SetMarkerColor(6);
+LZooChargeVsRun_tec5->SetLineColor(6);
+LZooChargeVsRun_tec6->SetMarkerColor(13);
+LZooChargeVsRun_tec6->SetLineColor(13);
+LZooChargeVsRun_tec7->SetMarkerColor(7);
+LZooChargeVsRun_tec7->SetLineColor(7);
+LZooChargeVsRun_tec8->SetMarkerColor(kOrange);
+LZooChargeVsRun_tec8->SetLineColor(kOrange);
+LZooChargeVsRun_tec9->SetMarkerColor(kYellow+2);
+LZooChargeVsRun_tec9->SetLineColor(kYellow+2);
+
+LZooChargeVsRun_tec1->SetMinimum(-1);
+LZooChargeVsRun_tec1->SetMaximum(1.);
+LZooChargeVsRun_tec1->Draw();
+LZooChargeVsRun_tec2->Draw("same");
+LZooChargeVsRun_tec3->Draw("same");
+LZooChargeVsRun_tec4->Draw("same");
+LZooChargeVsRun_tec5->Draw("same");
+LZooChargeVsRun_tec6->Draw("same");
+LZooChargeVsRun_tec7->Draw("same");
+LZooChargeVsRun_tec8->Draw("same");
+LZooChargeVsRun_tec9->Draw("same");
+cChargTec->SaveAs("ChargTec.pdf");
+
+//
+//----
+//
+
+}
+
+TH1D* extractMaximum(TH2D* histo2d,  TString namehist){
+
+   TH1D* histo_modif = new TH1D(namehist,namehist, histo2d->GetXaxis()->GetNbins(),histo2d->GetXaxis()->GetXmin(),histo2d->GetXaxis()->GetXmax());
+   for(int x=1;x<=histo2d->GetNbinsX();x++){
+      TH1D* Projection = (TH1D*)(histo2d->ProjectionY("proj",x,x))->Clone();   
+      
+      if (Projection->Integral()>100) {
+//       float maxval=Projection->GetXaxis()->GetBinCenter(Projection->GetMaximumBin());
+//       float rmsval=Projection->GetXaxis()->GetBinWidth(Projection->GetMaximumBin());
+       float maxval=Projection->GetMean();
+       float rmsval=Projection->GetMeanError();
+       histo_modif->SetBinContent(x,maxval);
+       histo_modif->SetBinError(x,rmsval);
+      }
+   }
+   return histo_modif;
+}
+TH1D* extractRMS(TH2D* histo2d,  TString namehist){
+
+   TH1D* histo_modif = new TH1D(namehist,namehist, histo2d->GetXaxis()->GetNbins(),histo2d->GetXaxis()->GetXmin(),histo2d->GetXaxis()->GetXmax());
+   for(int x=1;x<=histo2d->GetNbinsX();x++){
+      TH1D* Projection = (TH1D*)(histo2d->ProjectionY("proj",x,x))->Clone();   
+      
+      if (Projection->Integral()>100) {
+       float maxval=Projection->GetXaxis()->GetBinCenter(Projection->GetMaximumBin());
+//       float rmsval=Projection->GetXaxis()->GetBinWidth(Projection->GetMaximumBin());
+       float rmsval=Projection->GetRMS();
+       float errrmsval=Projection->GetRMSError();
+       histo_modif->SetBinContent(x,rmsval);
+       histo_modif->SetBinError(x,errrmsval);
+      }
+   }
+   return histo_modif;
+}
+
+TH1D* extractLandau(TH2D* histo2d, TString namehist){
+
+   int debug=0;
+   int debug2=0;
+   TH1D* histo_modif = new TH1D(namehist,namehist, histo2d->GetXaxis()->GetNbins(),histo2d->GetXaxis()->GetXmin(),histo2d->GetXaxis()->GetXmax());
+   for(int x=1;x<=histo2d->GetNbinsX();x++){
+      TH1D* Projection = (TH1D*)(histo2d->ProjectionY("proj",x,x))->Clone();   
+      
+      if (Projection->Integral()>1000) {
+       debug++;
+       float maxval=Projection->GetXaxis()->GetBinCenter(Projection->GetMaximumBin());
+       float liminf = maxval -2;
+       if (liminf<0) liminf=0;
+       float limsup = maxval + 3;
+       TF1* mylandau = new TF1("mylandau","[0]*TMath::Landau(x,[1],[2])",liminf, limsup);
+       mylandau->SetParameters(1,maxval,0.3); 
+       //int fstatus = Projection->Fit("mylandau","Q 0 RME");
+       mylandau->SetParLimits(0, 0.1, 1000000000.0);
+       mylandau->SetParLimits(1, 0.0001, 100.0);
+       mylandau->SetParLimits(2, 0.0001, 100.0);
+
+       TFitResultPtr r;
+       if (debug<-1) {
+          r = Projection->Fit("mylandau","S");
+          cout << " status :  " << r->Status() << "  validity " << r->IsValid() << endl;
+       }
+       else {r = Projection->Fit("mylandau","Q 0 RME S"); }
+
+//       if (!check && mylandau->GetParError(1)<0.1) {
+       if (!check) {
+         if (r->IsValid() && (r->Status()==0 || r->Status()==4000)) {
+          histo_modif->SetBinContent(x,mylandau->GetParameter(1));
+          histo_modif->SetBinError(x,mylandau->GetParError(1));
+         }
+       }
+       else if (which_check==1) {
+        int ndf=mylandau->GetNDF();
+        if (ndf<1) ndf=1;
+        histo_modif->SetBinContent(x,mylandau->GetChisquare()/ndf);
+        histo_modif->SetBinError(x,0.05*mylandau->GetChisquare()/ndf);
+       }
+       else if (which_check==2) {
+        if (r->IsValid()) {
+         histo_modif->SetBinContent(x,r->Status());
+//        histo_modif->SetBinContent(x,r->IsValid());
+         histo_modif->SetBinError(x,0.1);
+         if (r->Status()==4000 && debug2<10) {
+            debug2++;
+            cout << " ***** " << endl;
+            Projection->Fit("mylandau","S");
+            cout << " status :  " << r->Status() << "  validity " << r->IsValid() << endl;
+            cout << " ***** " << endl;
+         }
+        }
+      }
+     }
+   }
+   return histo_modif;
+}
+TH1D* extractGaus(TH2D* histo2d, TString namehist){
+
+   TH1D* histo_modif = new TH1D(namehist,namehist, histo2d->GetXaxis()->GetNbins(),histo2d->GetXaxis()->GetXmin(),histo2d->GetXaxis()->GetXmax());
+   for(int x=1;x<=histo2d->GetNbinsX();x++){
+      TH1D* Projection = (TH1D*)(histo2d->ProjectionY("proj",x,x))->Clone();   
+      
+      if (Projection->Integral()>1000) {
+       TF1* mygaus = new TF1("mygaus","[0]*TMath::Gaus(x,[1],[2])", 1, 6);
+       float maxval=Projection->GetXaxis()->GetBinCenter(Projection->GetMaximumBin());
+       mygaus->SetParameters(1,maxval,0.3); 
+       mygaus->SetParLimits(1, 0., 10.0);
+       mygaus->SetParLimits(2, 0., 10.0);
+//       int fstatus = Projection->Fit("mygaus","Q 0 RME");
+       TFitResultPtr r = Projection->Fit("mygaus","Q 0 RME S"); 
+//       if (!check && mygaus->GetParError(1)<0.3) {
+       if (!check) {
+        if(r->IsValid() && (r->Status()==0 || r->Status()==4000) && mygaus->GetParError(1)<0.1) {
+         histo_modif->SetBinContent(x,mygaus->GetParameter(1));
+         histo_modif->SetBinError(x,mygaus->GetParError(1));
+/*
+         if( mygaus->GetParameter(1)>0) {
+           histo_modif->SetBinContent(x,mygaus->GetParameter(2)/mygaus->GetParameter(1));
+           histo_modif->SetBinError(x,mygaus->GetParError(2)/mygaus->GetParameter(1));
+         }
+*/
+        }
+
+       }
+       else if (which_check==1) {
+        int ndf=mygaus->GetNDF();
+        if (ndf<1) ndf=1;
+        histo_modif->SetBinContent(x,mygaus->GetChisquare()/ndf);
+        histo_modif->SetBinError(x,0.05*mygaus->GetChisquare()/ndf);
+       }
+       else if (which_check==2) {
+        histo_modif->SetBinContent(x,r->Status());
+        histo_modif->SetBinError(x,0.1);
+       }
+      }
+   }
+   return histo_modif;
+}
+
+TH1D* extractVavilov(TH2D* histo2d, TString namehist){
+
+   TH1D* histo_modif = new TH1D(namehist,namehist, histo2d->GetXaxis()->GetNbins(),histo2d->GetXaxis()->GetXmin(),histo2d->GetXaxis()->GetXmax());
+   int debug=0;
+   for(int x=1;x<=histo2d->GetNbinsX();x++){
+      TH1D* Projection = (TH1D*)(histo2d->ProjectionY("proj",x,x))->Clone();
+      float maxval2=Projection->GetXaxis()->GetBinCenter(Projection->GetMaximumBin());
+      if (Projection->Integral()>1000) {
+       debug++;
+       Vavilov_Func* VVf=new Vavilov_Func();
+       TF1* TamasFunc  = new TF1("TamasFunc",VVf, maxval2-0.5,8,5,"Vavilov_Func");
+       TamasFunc->SetParameters(
+            0.01*maxval2,   // p[0]: kappa [0.01:10]
+            1.0,      
+            0.8*maxval2,        // p[2]: mpv
+            0.2*Projection->GetRMS(),         // p[3]: sigmaQ
+            0.5*Projection->Integral()      // p[4]: norm
+       );
+       TamasFunc->SetParLimits(0, 0.001, 10.0);
+       TamasFunc->SetParLimits(1, 0.9, 1.);
+       TamasFunc->SetParLimits(2, 0.5, 10.0);
+       TamasFunc->SetParLimits(3, 0.0, 100.0);
+       TamasFunc->SetParLimits(4, 0.0, 200000000.0);
+//       int fstatus = Projection->Fit(TamasFunc,"Q 0 RME");
+//       if (!check && TamasFunc->GetParError(2)<0.3) {
+//       TFitResultPtr r = Projection->Fit("TamasFunc","Q 0 RME S"); 
+       TFitResultPtr r;
+       if (debug<10) {
+          r = Projection->Fit("TamasFunc","S");
+          cout << " status :  " << r->Status() << "  validity " << r->IsValid() << endl;
+       }
+       else { r = Projection->Fit("TamasFunc","Q 0 RME S"); }
+
+       if (!check) {
+        if (r->IsValid() && (r->Status()==0 || r->Status()==4000)) {
+          histo_modif->SetBinContent(x,TamasFunc->GetParameter(2));
+          histo_modif->SetBinError(x,TamasFunc->GetParError(2));
+        }
+       }
+       else if (which_check==1) {
+        int ndf=TamasFunc->GetNDF();
+        if (ndf<1) ndf=1;
+        histo_modif->SetBinContent(x,TamasFunc->GetChisquare()/ndf);
+        histo_modif->SetBinError(x,0.05*TamasFunc->GetChisquare()/ndf);
+       }
+       else if (which_check==2) {
+//        histo_modif->SetBinContent(x,fstatus);
+        histo_modif->SetBinContent(x,r->Status());
+        histo_modif->SetBinError(x,0.1);
+       }  
+      }
+   }
+   return histo_modif;
+}
+
+
+TH1D* extractDiff(TFile* file1, TFile* file2, TString namehistin, TString namehistout){
+TH1D* L1 ;
+TH1D* L2 ;
+TH1D* Lout ;
+file1->cd();
+TString L1name = namehistin+"L1";
+L1 = extractGaus((TH2D*)gROOT->FindObject(namehistin),L1name);
+file2->cd();
+TString L2name = namehistin+"L2";
+L2 = extractGaus((TH2D*)gROOT->FindObject(namehistin),L2name);
+
+Lout = (TH1D*) L1->Clone();
+Lout->SetName(namehistout);
+Lout->Add(L2,-1.);
+
+return Lout;
+}
+
+
+void IntegratedResolution(){
+
+ TFile *_file0 = TFile::Open("analysis_ul_2017_tamas_v2.root");
+ TCanvas *c1 = new TCanvas("I", "I",10,32,782,552);
+    c1->SetFillColor(10);
+    c1->SetBorderMode(0);
+    c1->SetBorderSize(2);
+    c1->SetFrameFillColor(0);
+    c1->SetFrameBorderMode(0);
+    c1->cd();
+    gStyle->SetOptTitle(0);
+    gStyle->SetOptStat(0);
+
+    TH2D* IhNoL1 = (TH2D*)gROOT->FindObject("dEdX0NoL1VsRun");
+    TH2D* Ih15drop = (TH2D*)gROOT->FindObject("dEdXVsRun");
+    TH2D* IhStrip = (TH2D*)gROOT->FindObject("dEdX0stripVsRun");
+    TH2D* Ih15Strip = (TH2D*)gROOT->FindObject("dEdXstripVsRun");
+
+    TH1D* ProjectionIhNoL1 = (TH1D*)(IhNoL1->ProjectionY("proj"))->Clone();   
+    TH1D* ProjectionIh15drop = (TH1D*)(Ih15drop->ProjectionY("proj"))->Clone();   
+    TH1D* ProjectionIhStrip = (TH1D*)(IhStrip->ProjectionY("proj"))->Clone();   
+    TH1D* ProjectionIh15Strip = (TH1D*)(Ih15Strip->ProjectionY("proj"))->Clone();   
+      
+    TF1* mygaus1 = new TF1("mygaus1","[0]*TMath::Gaus(x,[1],[2])", 1, 6);
+    float maxval=ProjectionIhNoL1->GetXaxis()->GetBinCenter(ProjectionIhNoL1->GetMaximumBin());
+    mygaus1->SetParameters(1,maxval,0.3); 
+    ProjectionIhNoL1->Fit("mygaus1"); 
+    if ((mygaus1->GetParameter(1))>0) cout << " Resolution ProjectionIhNoL1 " << (mygaus1->GetParameter(2))/(mygaus1->GetParameter(1)) << endl;
+    cout << endl;
+
+    TF1* mygaus2 = new TF1("mygaus2","[0]*TMath::Gaus(x,[1],[2])", 1, 6);
+    float maxval2=ProjectionIh15drop->GetXaxis()->GetBinCenter(ProjectionIh15drop->GetMaximumBin());
+    mygaus2->SetParameters(1,maxval2,0.3); 
+    ProjectionIh15drop->Fit("mygaus2"); 
+    if ((mygaus2->GetParameter(1))>0) cout << " Resolution ProjectionIh15drop " << (mygaus2->GetParameter(2))/ (mygaus2->GetParameter(1)) << endl;
+
+    TF1* mygaus3 = new TF1("mygaus3","[0]*TMath::Gaus(x,[1],[2])", 1, 6);
+    float maxval3=ProjectionIhStrip->GetXaxis()->GetBinCenter(ProjectionIhStrip->GetMaximumBin());
+    mygaus3->SetParameters(1,maxval3,0.3); 
+    ProjectionIhStrip->Fit("mygaus3"); 
+    if ((mygaus3->GetParameter(1))>0) cout << " Resolution ProjectionIhStrip " << (mygaus3->GetParameter(2))/ (mygaus3->GetParameter(1)) << endl;
+
+    TF1* mygaus4 = new TF1("mygaus4","[0]*TMath::Gaus(x,[1],[2])", 1, 6);
+    float maxval4=ProjectionIh15Strip->GetXaxis()->GetBinCenter(ProjectionIh15Strip->GetMaximumBin());
+    mygaus4->SetParameters(1,maxval4,0.3); 
+    ProjectionIh15Strip->Fit("mygaus4"); 
+    if ((mygaus4->GetParameter(1))>0) cout << " Resolution ProjectionIh15Strip " << (mygaus4->GetParameter(2))/ (mygaus4->GetParameter(1)) << endl;
+
+
+    c1->cd();
+    ProjectionIhNoL1->SetLineColor(2);
+    ProjectionIhNoL1->SetMarkerColor(2);
+    mygaus1->SetLineColor(2);
+    ProjectionIh15drop->SetLineColor(4);
+    ProjectionIh15drop->SetMarkerColor(4);
+    mygaus2->SetLineColor(4);
+    ProjectionIhStrip->SetLineColor(8);
+    ProjectionIhStrip->SetMarkerColor(8);
+    mygaus3->SetLineColor(8);
+    ProjectionIh15Strip->SetLineColor(7);
+    ProjectionIh15Strip->SetMarkerColor(7);
+    mygaus4->SetLineColor(7);
+
+    if (ProjectionIhNoL1->GetMaximum() < ProjectionIh15drop->GetMaximum()) ProjectionIhNoL1->SetMaximum( ProjectionIh15drop->GetMaximum()*1.2);
+    if (ProjectionIhNoL1->GetMaximum() < ProjectionIhStrip->GetMaximum()) ProjectionIhNoL1->SetMaximum( ProjectionIhStrip->GetMaximum()*1.2);
+   
+    ProjectionIhNoL1->Draw();
+    mygaus1->Draw("same");
+    ProjectionIh15drop->Draw("same");
+    mygaus2->Draw("same");
+/*
+    ProjectionIhStrip->Draw("same");
+    mygaus3->Draw("same");
+*/
+    ProjectionIh15Strip->Draw("same");
+    mygaus4->Draw("same");
+
+
+
+}
+void extractQuantile(int caseQ=0){
+
+//TFile *_file0 = TFile::Open("analysis_orig_v2.root");
+TFile *_file0 = TFile::Open("analysis_tamas_17v2_18v1.root");
+
+TCanvas *c1 = new TCanvas("Ih", "Ih",10,32,782,552);
+    c1->SetFillColor(10);
+    c1->SetBorderMode(0);
+    c1->SetBorderSize(2);
+    c1->SetFrameFillColor(0);
+    c1->SetFrameBorderMode(0);
+    c1->cd();
+    gStyle->SetOptTitle(0);
+    gStyle->SetOptStat(0);
+
+TH1D* LdEdXVsRun;
+TH1D* LdEdXpixVsRun;
+TH1D* LdEdXstripVsRun;
+
+ 
+ LdEdXVsRun = extractQuantile((TH2D*)gROOT->FindObject("dEdXVsRun"),"LdEdXVsRun",caseQ);
+ LdEdXpixVsRun = extractQuantile((TH2D*)gROOT->FindObject("dEdXpixVsRun"),"LdEdXpixVsRun",caseQ);
+ LdEdXstripVsRun = extractQuantile((TH2D*)gROOT->FindObject("dEdXstripVsRun"),"LdEdXstripVsRun",caseQ);
+
+ LdEdXpixVsRun->SetMarkerColor(2);
+ LdEdXpixVsRun->SetLineColor(2);
+ LdEdXstripVsRun->SetMarkerColor(8);
+ LdEdXstripVsRun->SetLineColor(8);
+
+  LdEdXVsRun->SetMinimum(2.);
+  LdEdXVsRun->SetMaximum(4.5);
+//  LdEdXVsRun->GetXaxis()->SetRangeUser(295000, 325000);
+
+ LdEdXVsRun->Draw();
+ LdEdXpixVsRun->Draw("same");
+ LdEdXstripVsRun->Draw("same");
+
+ if (caseQ==0) c1->SaveAs("Ih_quantile90.pdf");
+ else if (caseQ==1) c1->SaveAs("Ih_quantile95.pdf");
+ else if (caseQ==2) c1->SaveAs("Ih_quantile99.pdf");
+ else if (caseQ==2) c1->SaveAs("Ih_quantile75.pdf");
+
+
+//
+//---
+
+
+
+TCanvas *c0 = new TCanvas("Ih_0", "Ih_0",10,32,782,552);
+c0->SetFillColor(10);
+c0->SetBorderMode(0);
+c0->SetBorderSize(2);
+c0->SetFrameFillColor(0);
+c0->SetFrameBorderMode(0);
+c0->cd();
+gStyle->SetOptTitle(0);
+gStyle->SetOptStat(0);
+
+TH1D* LdEdX0VsRun = extractQuantile((TH2D*)gROOT->FindObject("dEdX0VsRun"),"LdEdX0VsRun",caseQ);
+TH1D* LdEdX0pixVsRun = extractQuantile((TH2D*)gROOT->FindObject("dEdX0pixVsRun"),"LdEdX0pixVsRun",caseQ);
+TH1D* LdEdX0stripVsRun = extractQuantile((TH2D*)gROOT->FindObject("dEdX0stripVsRun"),"LdEdX0stripVsRun",caseQ);
+
+LdEdX0pixVsRun->SetMarkerColor(2);
+LdEdX0pixVsRun->SetLineColor(2);
+LdEdX0stripVsRun->SetMarkerColor(8);
+LdEdX0stripVsRun->SetLineColor(8);
+
+  LdEdX0VsRun->SetMinimum(2.);
+  LdEdX0VsRun->SetMaximum(4.5);
+//  LdEdX0VsRun->GetXaxis()->SetRangeUser(295000, 325000);
+
+LdEdX0VsRun->Draw();
+LdEdX0pixVsRun->Draw("same");
+LdEdX0stripVsRun->Draw("same");
+ if (caseQ==0) c0->SaveAs("Ih0_quantile90.pdf");
+ else if (caseQ==1) c0->SaveAs("Ih0_quantile95.pdf");
+ else if (caseQ==2) c0->SaveAs("Ih0_quantile99.pdf");
+ else if (caseQ==3) c0->SaveAs("Ih0_quantile75.pdf");
+
+TCanvas *c2_c = new TCanvas("Ih0 NoL1", "Ih0 NoL1",10,32,782,552);
+    c2_c->SetFillColor(10);
+    c2_c->SetBorderMode(0);
+    c2_c->SetBorderSize(2);
+    c2_c->SetFrameFillColor(0);
+    c2_c->SetFrameBorderMode(0);
+    c2_c->cd();
+    gStyle->SetOptTitle(0);
+    gStyle->SetOptStat(0);
+
+TH1D* LadEdX0VsRun = extractQuantile((TH2D*)gROOT->FindObject("dEdX0NoL1VsRun"),"LadEdX0VsRun",caseQ);
+TH1D* LadEdX0pixVsRun = extractQuantile((TH2D*)gROOT->FindObject("dEdX0NoL1pixVsRun"),"LadEdX0pixVsRun",caseQ);
+
+LadEdX0pixVsRun->SetMarkerColor(2);
+LadEdX0pixVsRun->SetLineColor(2);
+
+LadEdX0VsRun->SetMinimum(2.);
+LadEdX0VsRun->SetMaximum(4.5);
+//  LadEdX0VsRun->GetXaxis()->SetRangeUser(295000, 325000);
+
+LadEdX0VsRun->Draw();
+LadEdX0pixVsRun->Draw("same");
+LdEdX0stripVsRun->Draw("same");
+ if (caseQ==0) c2_c->SaveAs("Ih0NoL1_quantile90.pdf");
+ else if (caseQ==1) c2_c->SaveAs("Ih0NoL1_quantile95.pdf");
+ else if (caseQ==2) c2_c->SaveAs("Ih0NoL1_quantile99.pdf");
+ else if (caseQ==3) c2_c->SaveAs("Ih0NoL1_quantile75.pdf");
+
+
+
+TCanvas *c2_a = new TCanvas("SuperPos","SuperPos",10,32,782,552);
+    c2_a->SetFillColor(10);
+    c2_a->SetBorderMode(0);
+    c2_a->SetBorderSize(2);
+    c2_a->SetFrameFillColor(0);
+    c2_a->SetFrameBorderMode(0);
+    c2_a->cd();
+    gStyle->SetOptTitle(0);
+    gStyle->SetOptStat(0);
+
+LadEdX0VsRun->SetMarkerColor(2);
+LadEdX0VsRun->SetLineColor(2);
+LdEdXVsRun->SetMarkerColor(4);
+LdEdXVsRun->SetLineColor(4);
+LdEdX0stripVsRun->SetMarkerColor(8);
+LdEdX0stripVsRun->SetLineColor(8);
+LdEdXstripVsRun->SetMarkerColor(7);
+LdEdXstripVsRun->SetLineColor(7);
+
+LadEdX0VsRun->SetMinimum(2.);
+LadEdX0VsRun->SetMaximum(4.5);
+//LadEdX0VsRun->GetXaxis()->SetRangeUser(295000, 325000);
+
+LadEdX0VsRun->Draw(); // Ih with no L1
+LdEdXVsRun->Draw("same"); // Ih with 15% drop
+LdEdX0stripVsRun->Draw("same"); // Ih, strip only
+LdEdXstripVsRun->Draw("same"); // Ih with 15% drop, strip only
+
+ if (caseQ==0) c2_a->SaveAs("IhSup_quantile90.pdf");
+ else if (caseQ==1) c2_a->SaveAs("IhSup_quantile95.pdf");
+ else if (caseQ==2) c2_a->SaveAs("IhSup_quantile99.pdf");
+ else if (caseQ==3) c2_a->SaveAs("IhSup_quantile75.pdf");
+
+
+}
+
+TH1D* extractQuantile(TH2D* histo2d, TString namehist, int caseQ){
+
+   TH1D* histo_modif = new TH1D(namehist,namehist, histo2d->GetXaxis()->GetNbins(),histo2d->GetXaxis()->GetXmin(),histo2d->GetXaxis()->GetXmax());
+   Double_t xq[4] = {0.9,0.95,0.99,0.75};
+   Double_t yq[4];
+   if (caseQ<0 || caseQ>=4) {
+       cout << "wrong caseQ value for the quantile determination --> between 0 and 3 ! " << endl;
+       return histo_modif;
+   }
+   for(int x=1;x<=histo2d->GetNbinsX();x++){
+      TH1D* Projection = (TH1D*)(histo2d->ProjectionY("proj",x,x))->Clone();   
+      if (Projection->Integral()>1000) {
+       yq[0]=0;
+       yq[1]=0;
+       yq[2]=0;
+       Projection->GetQuantiles(4,yq,xq);
+       histo_modif->SetBinContent(x,yq[caseQ]);
+       histo_modif->SetBinError(x,yq[caseQ]*0.001);
+      }
+   }
+   return histo_modif;
+}
+
+
+void testProj(){
+
+TFile *_file0 = TFile::Open("analysis_orig_v2.root");
+//TFile *_file0 = TFile::Open("analysis_tamas_17v2_18v1.root");
+
+TCanvas *c1 = new TCanvas("Ih", "Ih",10,32,782,552);
+    c1->SetFillColor(10);
+    c1->SetBorderMode(0);
+    c1->SetBorderSize(2);
+    c1->SetFrameFillColor(0);
+    c1->SetFrameBorderMode(0);
+    c1->cd();
+    gStyle->SetOptTitle(0);
+
+ TH2D* histo2d= (TH2D*) gROOT->FindObject("dEdX0stripVsRun");
+ TH1D* histo_modif = new TH1D("histo_proj","histo_proj", 200, 3.1, 3.5);
+ TH1D* histo_modif2 = new TH1D("run","run", histo2d->GetXaxis()->GetNbins(),histo2d->GetXaxis()->GetXmin(),histo2d->GetXaxis()->GetXmax());
+
+ float minx=10;
+ float maxx=0;
+   for(int x=1;x<=histo2d->GetNbinsX();x++){
+      TH1D* Projection = (TH1D*)(histo2d->ProjectionY("proj",x,x))->Clone();   
+      
+      if (Projection->Integral()>1000) {
+       TF1* mygaus = new TF1("mygaus","[0]*TMath::Gaus(x,[1],[2])", 1, 6);
+       float maxval=Projection->GetXaxis()->GetBinCenter(Projection->GetMaximumBin());
+       mygaus->SetParameters(1,maxval,0.3); 
+       mygaus->SetParLimits(1, 0., 10.0);
+       mygaus->SetParLimits(2, 0., 10.0);
+       TFitResultPtr r = Projection->Fit("mygaus","Q 0 RME S"); 
+        if(r->IsValid() && (r->Status()==0 || r->Status()==4000) && mygaus->GetParError(1)<0.1) {
+           histo_modif->Fill(mygaus->GetParameter(1));
+           histo_modif2->SetBinContent(x,mygaus->GetParameter(1));
+           histo_modif2->SetBinError(x,mygaus->GetParError(1));
+           if (mygaus->GetParameter(1)<minx) minx=mygaus->GetParameter(1);
+           if (mygaus->GetParameter(1)>maxx) maxx=mygaus->GetParameter(1);
+        }
+      }
+   }
+
+  histo_modif->Draw();
+  cout << "minx = "<< minx << endl;
+  cout << "maxx = "<< maxx << endl;
+  cout << "diff = "<< maxx-minx << endl;
+
+TCanvas *c2 = new TCanvas("Ih2", "Ih2",10,32,782,552);
+    c2->SetFillColor(10);
+    c2->SetBorderMode(0);
+    c2->SetBorderSize(2);
+    c2->SetFrameFillColor(0);
+    c2->SetFrameBorderMode(0);
+    c2->cd();
+    gStyle->SetOptTitle(0);
+   histo_modif2->Draw();
+
+}
+
+void testIh(){
+
+TFile *_file0 = TFile::Open("analysis_orig_v2.root");
+//TH2D* LdEdXVsRun0 = (TH2D*)gROOT->FindObject("dEdXVsRun");
+//TH2D* LdEdXVsRun0 = (TH2D*)gROOT->FindObject("ChargeVsRun_pixl2");
+TH2D* LdEdXVsRun0 = (TH2D*)gROOT->FindObject("dEdXpixVsRun");
+TFile *_file1 = TFile::Open("analysis_tamas_v2_n3.root");
+//TH2D* LdEdXVsRun1 = (TH2D*)gROOT->FindObject("dEdXVsRun");
+//TH2D* LdEdXVsRun1 = (TH2D*)gROOT->FindObject("ChargeVsRun_pixl2");
+TH2D* LdEdXVsRun1 = (TH2D*)gROOT->FindObject("dEdXpixVsRun");
+
+
+TCanvas *c1 = new TCanvas("Ih", "Ih",10,32,782,552);
+    c1->SetFillColor(10);
+    c1->SetBorderMode(0);
+    c1->SetBorderSize(2);
+    c1->SetFrameFillColor(0);
+    c1->SetFrameBorderMode(0);
+    c1->cd();
+    gStyle->SetOptTitle(0);
+    gStyle->SetOptStat(0);
+
+ TH1D* Projection0 = (TH1D*)(LdEdXVsRun0->ProjectionY("proj",511,511))->Clone();   
+ TH1D* Projection1 = (TH1D*)(LdEdXVsRun1->ProjectionY("proj",511,511))->Clone();   
+
+ Projection0->Draw("hist");
+ Projection1->SetLineColor(2);
+ Projection1->Draw("hist,same");
+ c1->SaveAs("test_Ihpix.pdf");
+
+ float a0 = Projection0->GetMean();
+ float a1 = Projection1->GetMean();
+ cout <<" a1/a0 " << a1*1./a0 << endl;
+
+
+}
+
+TH2D* modif2DHisto(TH2D* histo, TString namehist) {
+     TH2D* modif= (TH2D*) histo->Clone();
+     modif->SetName(namehist);
+     for(int x=1;x<histo->GetXaxis()->GetNbins()+1;x++){
+          TH1D* Projection = (TH1D*)(histo->ProjectionY("proj",x,x))->Clone();
+          for (int y=1;y<histo->GetYaxis()->GetNbins()+1;y++) {
+            if (Projection->Integral()>0) {
+             modif->SetBinContent(x,y,histo->GetBinContent(x,y)/Projection->Integral());
+             modif->SetBinError(x,y,histo->GetBinError(x,y)/Projection->Integral());
+            }
+          }
+     }
+     return modif;
+}
+
+
+TH2D* correl2DHisto(TH1D* histo1, TH1D* histo2, TString namehist, TString namecap){
+//     TH2D* modif = new TH2D(namehist,namecap,50,histo1->GetMinimum()*0.90, histo1->GetMaximum()*1.1, 50, histo2->GetMinimum()*0.90, histo2->GetMaximum()*1.1); 
+     TH2D* modif = new TH2D(namehist,namecap,50,histo1->GetMinimum(), histo1->GetMaximum(), 50, histo2->GetMinimum(), histo2->GetMaximum()); 
+     for (int i=0; i<histo1->GetXaxis()->GetNbins()+1; i++) {
+        float valx1=histo1->GetBinContent(i);
+        float valx2=histo2->GetBinContent(i);
+        if (valx1>0 && valx2>0) {
+           modif->Fill(valx1,valx2);
+        }
+  
+     }
+     modif->SetMarkerStyle(21);
+     return modif;
+
+}
+
+TH1D* extractVariationGaus(TH2D* histo2d, TString namehist, int nbin, float x1, float x2){
+
+   TH1D* histo_modif = new TH1D(namehist,namehist, nbin, x1, x2);
+   for(int x=1;x<=histo2d->GetNbinsX();x++){
+      TH1D* Projection = (TH1D*)(histo2d->ProjectionY("proj",x,x))->Clone();   
+      
+      if (Projection->Integral()>1000) {
+       TF1* mygaus = new TF1("mygaus","[0]*TMath::Gaus(x,[1],[2])", 1, 6);
+       float maxval=Projection->GetXaxis()->GetBinCenter(Projection->GetMaximumBin());
+       mygaus->SetParameters(1,maxval,0.3); 
+       mygaus->SetParLimits(1, 0., 10.0);
+       mygaus->SetParLimits(2, 0., 10.0);
+//       int fstatus = Projection->Fit("mygaus","Q 0 RME");
+       TFitResultPtr r = Projection->Fit("mygaus","Q 0 RME S"); 
+//       if (!check && mygaus->GetParError(1)<0.3) {
+       if (!check) {
+        if(r->IsValid() && (r->Status()==0 || r->Status()==4000) && mygaus->GetParError(1)<0.1) {
+         histo_modif->Fill(mygaus->GetParameter(1),Projection->Integral());
+/*
+         if( mygaus->GetParameter(1)>0) {
+           histo_modif->SetBinContent(x,mygaus->GetParameter(2)/mygaus->GetParameter(1));
+           histo_modif->SetBinError(x,mygaus->GetParError(2)/mygaus->GetParameter(1));
+         }
+*/
+        }
+
+       }
+      }
+   }
+   return histo_modif;
+}
+TH1D* extractVariationMaximum(TH2D* histo2d,  TString namehist, int nbin, float x1, float x2){
+
+   TH1D* histo_modif = new TH1D(namehist,namehist, nbin, x1, x2);
+   for(int x=1;x<=histo2d->GetNbinsX();x++){
+      TH1D* Projection = (TH1D*)(histo2d->ProjectionY("proj",x,x))->Clone();   
+      
+      if (Projection->Integral()>100) {
+//       float maxval=Projection->GetXaxis()->GetBinCenter(Projection->GetMaximumBin());
+//       float rmsval=Projection->GetXaxis()->GetBinWidth(Projection->GetMaximumBin());
+       float maxval=Projection->GetMean();
+       float rmsval=Projection->GetMeanError();
+       histo_modif->Fill(maxval,Projection->Integral());
+      }
+   }
+   return histo_modif;
+}

--- a/Analyzer/test/Tamas/HSCParticleProducerAnalyzer_master_cfg.py
+++ b/Analyzer/test/Tamas/HSCParticleProducerAnalyzer_master_cfg.py
@@ -96,6 +96,7 @@ if(not options.isSkimmedSample):
           "HLT_PFHT500_PFMET100_PFMHT100_IDTight_v*",
           "HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_PFHT60_v*",
           "HLT_MET105_IsoTrk50_v*",
+          "HLT_isoMu*",
       ]
    else:
       #do not apply trigger filter on signal
@@ -203,7 +204,7 @@ if options.SAMPLE == 'isData':
         K = 2.3
         C = 3.17
         SF0 = 1.0
-        SF1 = 1.0325
+        SF1 = 0.990
         if options.ERA == 'A':
             IasTemplate = 'template_2017B_v4.root'
         if options.ERA == 'B':
@@ -224,7 +225,7 @@ if options.SAMPLE == 'isData':
         K = 2.27
         C = 3.16
         SF0 = 1.0
-        SF1 = 1.0817
+        SF1 = 1.035
         if options.ERA == 'A':
             IasTemplate = 'template_2018A_v4.root'
         if options.ERA == 'B':
@@ -239,28 +240,28 @@ else:
         if options.YEAR == '2017':
             K = 2.26
             C = 3.22
-            SF0 = 1.0079
-            SF1 = 1.0875
+            SF0 = 1.009
+            SF1 = 1.044
             IasTemplate = 'template_2017MC_v4.root'
         if options.YEAR == '2018':
             K = 2.27
             C = 3.22
-            SF0 = 1.0047
-            SF1 = 1.1429
+            SF0 = 1.006
+            SF1 = 1.097
             IasTemplate = 'template_2018MC_v4.root'
     else:
         SampleType = 2
         if options.YEAR == '2017':
             K = 2.26
             C = 3.22
-            SF0 = 1.0079
-            SF1 = 1.0875
+            SF0 = 1.009
+            SF1 = 1.044
             IasTemplate = 'template_2017MC_v4.root'
         if options.YEAR == '2018':
             K = 2.27
             C = 3.22
-            SF0 = 1.0047
-            SF1 = 1.1429
+            SF0 = 1.006
+            SF1 = 1.097
             IasTemplate = 'template_2018MC_v4.root'
 
 process.load("SUSYBSMAnalysis.Analyzer.HSCParticleAnalyzer_cfi")


### PR DESCRIPTION
- Add pixel cleaning requierements for the Ih computation (computedEdx function in CommonFunction), based on probQ and reCPE. This request to pass a lot of info to the function :(   --> globalIh_ is now using the cleaning in the pixel. some plots have been produced in CR and CR_verylowPt regions to check the effect. This will has an impact on the K and C values.
- Add saturation correction and strip cleaning for the Gi templates (I haven't pushed the pixel cleaning as we don't use the templates in the pixel but it would be better to add it too in the future) ==> ACTION : new templates need to be redone
- dEdxSF have been updated : I found a change in the Strip/Pixel SF when Fpix>0.3 is applied. This will have an impact on the K and C value. 
- new plots to answer questions from Slava : Charge/pathlength per layer, Ih resolution in CR_verylowPt, NSat at low p and at large p (to check Sig and Bg MC). I also add some plot for the dEdX SF determination.