### PR TITLE
Adding cleaning in the plots for dedx SF extraction

### DIFF
--- a/Analyzer/interface/CommonFunction.h
+++ b/Analyzer/interface/CommonFunction.h
@@ -265,6 +265,7 @@ float GetSFPixel(int subdetid_, UInt_t detid_, string year, int run) {
         else {
                 layerorside = int((detid_>>20)&0xF);
         }
+
    }
    if (subdetid_==2) {
         pix =2 ;
@@ -1696,6 +1697,7 @@ crossTalkInvAlgo=1;
         SiStripDetId SSdetId(detid);
         moduleGeometry = SSdetId.moduleGeometry();
       }
+/*
       if (detid.subdetId() == 3) {
         layer = ((detid >> 14) & 0x7);
       }  //TIB
@@ -1708,6 +1710,11 @@ crossTalkInvAlgo=1;
       if (detid.subdetId() == 6) {
         layer = ((detid >> 5) & 0x7) + 13;
       }  //TEC
+*/
+      if (detid.subdetId() == StripSubdetector::TIB) layer= abs(int(tTopo->tibLayer(detid)));
+      if (detid.subdetId() == StripSubdetector::TOB) layer= abs(int(tTopo->tobLayer(detid))) + 4;
+      if (detid.subdetId() == StripSubdetector::TID) layer= abs(int(tTopo->tidWheel(detid))) + 10;
+      if (detid.subdetId() == StripSubdetector::TEC) layer= abs(int(tTopo->tecWheel(detid))) + 13;
 
       //skip templates ias = 1 --> skip pixel, TIB, TID, 3 first TEC layers
       if (skip_templates_ias == 1 && (
@@ -1719,10 +1726,15 @@ crossTalkInvAlgo=1;
         ){continue;}
 
       //skip templates ias = 2 --> pixel only, with pixL1 or not
+      //
+      bool isBPIXL1=false;
+      int numLayers = tkGeometry->numberOfLayers(PixelSubdetector::PixelBarrel);
+      if ((numLayers == 4) && ((detid.subdetId() == PixelSubdetector::PixelBarrel) && (tTopo->pxbLayer(detid) == 1))) isBPIXL1=true;  // only for 2017 and 2018
       if (skip_templates_ias == 2 && (
                   detid.subdetId()>2 ||
+                  isBPIXL1 
                   //(skipPixelL1 && detid.subdetId() == 1 && ((detid >> 16) & 0xF) == 1) //decoding mask for 2016 !
-                  (skipPixelL1 && detid.subdetId() == 1 && ((detid >> 20) & 0xF) == 1) //decoding mask for 2017-2018
+                  //(skipPixelL1 && detid.subdetId() == 1 && ((detid >> 20) & 0xF) == 1) //decoding mask for 2017-2018
                   )
         ){continue;}
 

--- a/Analyzer/interface/Tuple.h
+++ b/Analyzer/interface/Tuple.h
@@ -769,6 +769,8 @@ struct Tuple {
   TH2F* PostPreS_ProbQNoL1VsIas_CR_Ias_down;
   TH2F* PostPreS_ProbQNoL1VsIas_CR_Pt_up;
   TH2F* PostPreS_ProbQNoL1VsIas_CR_Pt_down;
+  TH2F* PostPreS_MassVsIas_fail_CR;
+  TH2F* PostPreS_MassVsIas_pass_CR;
  
   TH1F* PostPreS_Ih_CR_veryLowPt;
   TH1F* PostPreS_Ihstrip_CR_veryLowPt;
@@ -1468,6 +1470,12 @@ struct Tuple {
  TH2D* SF_HHit2DStrip;
  TH2D* SF_HHit2DPix_nosf;
  TH2D* SF_HHit2DStrip_nosf;
+ TH2D* SF_HHit2DPix_eta1;
+ TH2D* SF_HHit2DStrip_eta1;
+ TH2D* SF_HHit2DPix_nosf_eta1;
+ TH2D* SF_HHit2DStrip_nosf_eta1;
+ TH2D* SF_HHit2DPix_vs_eta;
+ TH2D* SF_HHit2DStrip_vs_eta;
 
  // K and C
  TH2D* K_and_C_Ih_noL1_VsP_loose1;
@@ -1491,6 +1499,9 @@ struct Tuple {
  TH2D* K_and_C_Ih_noL1_VsP_noFcut2;
  TH2D* K_and_C_Ih_strip_VsP_noFcut1;
  TH2D* K_and_C_Ih_strip_VsP_noFcut2;
+
+ TH1F* K_and_C_Ih_noL1_1d;
+ TH1F* K_and_C_Ih_strip_1d;
 
  TH1F* K_and_C_Kin_Mass;
  TH1F* K_and_C_Kin_p;

--- a/Analyzer/interface/TupleMaker.h
+++ b/Analyzer/interface/TupleMaker.h
@@ -1140,6 +1140,10 @@ void TupleMaker::initializeTuple(Tuple *&tuple,
     tuple->PostPreS_Ihstrip_CR= dir.make<TH1F>("PostPreS_Ihstrip_CR", ";I_{h} (strip only) (MeV/cm)", 200, 0, dEdxM_UpLim);
     tuple->PostPreS_Ih_nopixcl_CR= dir.make<TH1F>("PostPreS_Ih_nopixcl_CR", ";I_{h}(no pix cleaning) (MeV/cm)", 200, 0, dEdxM_UpLim);
     tuple->PostPreS_Pt_lowPt_CR = dir.make<TH1F>("PostPreS_Pt_lowPt_CR", ";p_{T} (GeV);Tracks / 10 GeV", 50, 0., 500.);
+    tuple->PostPreS_MassVsIas_fail_CR= dir.make<TH2F>("PostPreS_MassVsIas_fail_CR", ";G_{i}^{strips} in Fail ; Mass(GeV)",10,0,1, 80, 0, 4000);
+    tuple->PostPreS_MassVsIas_pass_CR= dir.make<TH2F>("PostPreS_MassVsIas_pass_CR", ";G_{i}^{strips} in Pass ; Mass(GeV)",10,0,1, 80, 0, 4000);
+
+
     tuple->PostPreS_Ias_CR_veryLowPt = dir.make<TH1F>("PostPreS_Ias_CR_veryLowPt", ";G_{i}^{strips};Tracks / 0.1", 10, 0, dEdxS_UpLim);
     tuple->PostPreS_P_CR_veryLowPt = dir.make<TH1F>("PostPreS_P_CR_veryLowPt", ";p (GeV);Tracks / 10 GeV", 50, 0., 50);
     tuple->PostPreS_Pt_lowPt = dir.make<TH1F>("PostPreS_Pt_lowPt", ";p_{T} (GeV);Tracks / 10 GeV", 50, 0., 500.);
@@ -2018,29 +2022,38 @@ void TupleMaker::initializeTuple(Tuple *&tuple,
     tuple->SF_HHit2DStrip =  dir.make<TH2D>("SF_HHit2DStrip", ";SF_HHit2DStrip",  50, 0., 100., 200, 0., 20.);
     tuple->SF_HHit2DPix_nosf   =  dir.make<TH2D>("SF_HHit2DPix_nosf", ";SF_HHit2DPix_nosf",  50, 0., 100., 200, 0., 20.);
     tuple->SF_HHit2DStrip_nosf =  dir.make<TH2D>("SF_HHit2DStrip_nosf", ";SF_HHit2DStrip_nosf",  50, 0., 100., 200, 0., 20.);
+    tuple->SF_HHit2DPix_eta1   =  dir.make<TH2D>("SF_HHit2DPix_eta1", ";SF_HHit2DPix_eta1",  50, 0., 100., 200, 0., 20.);
+    tuple->SF_HHit2DStrip_eta1 =  dir.make<TH2D>("SF_HHit2DStrip_eta1", ";SF_HHit2DStrip_eta1",  50, 0., 100., 200, 0., 20.);
+    tuple->SF_HHit2DPix_nosf_eta1  =  dir.make<TH2D>("SF_HHit2DPix_nosf_eta1", ";SF_HHit2DPix_nosf_eta1",  50, 0., 100., 200, 0., 20.);
+    tuple->SF_HHit2DStrip_nosf_eta1 =  dir.make<TH2D>("SF_HHit2DStrip_nosf_eta1", ";SF_HHit2DStrip_nosf_eta1",  50, 0., 100., 200, 0., 20.);
+    tuple->SF_HHit2DPix_vs_eta  =  dir.make<TH2D>("SF_HHit2DPix_vs_eta", ";SF_HHit2DPix_vs_eta",  42, -2.1, 2.1, 200, 0., 20.);
+    tuple->SF_HHit2DStrip_vs_eta =  dir.make<TH2D>("SF_HHit2DStrip_vs_eta", ";SF_HHit2DStrip_vs_eta",  42, -2.1, 2.1, 200, 0., 20.);
 
   // K and C
-    tuple->K_and_C_Ih_noL1_VsP_loose1 = dir.make<TH2D>("K_and_C_Ih_noL1_VsP_loose1",";P_loose1;Ih_noL1", 50,0,5, 80, 2.,10.);
-    tuple->K_and_C_Ih_noL1_VsP_loose2 = dir.make<TH2D>("K_and_C_Ih_noL1_VsP_loose2",";P_loose2;Ih_noL1", 250,0,50, 80, 2.,10.);
-    tuple->K_and_C_Ih_noL1_VsP_eta1_loose1 = dir.make<TH2D>("K_and_C_Ih_noL1_VsP_eta1_loose1",";eta1_loose1;Ih_noL1", 50,0,5, 80, 2.,10.);
-    tuple->K_and_C_Ih_noL1_VsP_eta1_loose2 = dir.make<TH2D>("K_and_C_Ih_noL1_VsP_eta1_loose2",";eta1_loose2;Ih_noL1", 250,0,50, 80, 2.,10.);
-    tuple->K_and_C_Ih_noL1_VsP_eta2_loose1 = dir.make<TH2D>("K_and_C_Ih_noL1_VsP_eta2_loose1",";P_eta2_loose1;Ih_noL1", 50,0,5, 80, 2.,10.);
-    tuple->K_and_C_Ih_noL1_VsP_eta2_loose2 = dir.make<TH2D>("K_and_C_Ih_noL1_VsP_eta2_loose2",";P_eta2_loose2;Ih_noL1", 250,0,50, 80, 2.,10.);
-    tuple->K_and_C_Ih_strip_VsP_loose1 = dir.make<TH2D>("K_and_C_Ih_strip_VsP_loose1",";P_loose1;Ih_strip", 50,0,5, 80, 2.,10.);
-    tuple->K_and_C_Ih_strip_VsP_loose2 = dir.make<TH2D>("K_and_C_Ih_strip_VsP_loose2",";P_loose2;Ih_strip", 250,0,50, 80, 2.,10.);
+    tuple->K_and_C_Ih_noL1_VsP_loose1 = dir.make<TH2D>("K_and_C_Ih_noL1_VsP_loose1",";P_loose1;Ih_noL1", 50,0,5, 240, 2.,14.);
+    tuple->K_and_C_Ih_noL1_VsP_loose2 = dir.make<TH2D>("K_and_C_Ih_noL1_VsP_loose2",";P_loose2;Ih_noL1", 250,0,50, 240, 2.,14.);
+    tuple->K_and_C_Ih_noL1_VsP_eta1_loose1 = dir.make<TH2D>("K_and_C_Ih_noL1_VsP_eta1_loose1",";eta1_loose1;Ih_noL1", 50,0,5, 240, 2., 14.);
+    tuple->K_and_C_Ih_noL1_VsP_eta1_loose2 = dir.make<TH2D>("K_and_C_Ih_noL1_VsP_eta1_loose2",";eta1_loose2;Ih_noL1", 250,0,50, 240, 2., 14.);
+    tuple->K_and_C_Ih_noL1_VsP_eta2_loose1 = dir.make<TH2D>("K_and_C_Ih_noL1_VsP_eta2_loose1",";P_eta2_loose1;Ih_noL1", 50,0,5, 240, 2., 14.);
+    tuple->K_and_C_Ih_noL1_VsP_eta2_loose2 = dir.make<TH2D>("K_and_C_Ih_noL1_VsP_eta2_loose2",";P_eta2_loose2;Ih_noL1", 250,0,50, 240, 2., 14.);
+    tuple->K_and_C_Ih_strip_VsP_loose1 = dir.make<TH2D>("K_and_C_Ih_strip_VsP_loose1",";P_loose1;Ih_strip", 50,0,5, 240, 2., 14.);
+    tuple->K_and_C_Ih_strip_VsP_loose2 = dir.make<TH2D>("K_and_C_Ih_strip_VsP_loose2",";P_loose2;Ih_strip", 250,0,50, 240, 2., 14.);
 
-    tuple->K_and_C_Ih_noL1_VsP_1 = dir.make<TH2D>("K_and_C_Ih_noL1_VsP_1",";Ih_noL1_VsP_1", 50,0,5, 80, 2.,10.);
-    tuple->K_and_C_Ih_noL1_VsP_2 = dir.make<TH2D>("K_and_C_Ih_noL1_VsP_2",";Ih_noL1_VsP_2", 250,0,50, 80, 2.,10.);
-    tuple->K_and_C_Ih_noL1_VsP_eta1_1 = dir.make<TH2D>("K_and_C_Ih_noL1_VsP_eta1_1",";Ih_noL1_VsP_eta1_1", 50,0,5, 80, 2.,10.);
-    tuple->K_and_C_Ih_noL1_VsP_eta1_2 = dir.make<TH2D>("K_and_C_Ih_noL1_VsP_eta1_2",";Ih_noL1_VsP_eta1_2", 250,0,50, 80, 2.,10.);
-    tuple->K_and_C_Ih_noL1_VsP_eta2_1 = dir.make<TH2D>("K_and_C_Ih_noL1_VsP_eta2_1",";Ih_noL1_VsP_eta2_1", 50,0,5, 80, 2.,10.);
-    tuple->K_and_C_Ih_noL1_VsP_eta2_2 = dir.make<TH2D>("K_and_C_Ih_noL1_VsP_eta2_2",";Ih_noL1_VsP_eta2_2", 250,0,50, 80, 2.,10.);
-    tuple->K_and_C_Ih_strip_VsP_1 = dir.make<TH2D>("K_and_C_Ih_strip_VsP_1",";Ih_strip_VsP_1", 50,0,5, 80, 2.,10.);
-    tuple->K_and_C_Ih_strip_VsP_2 = dir.make<TH2D>("K_and_C_Ih_strip_VsP_2",";Ih_strip_VsP_2", 250,0,50, 80, 2.,10.);
-    tuple->K_and_C_Ih_noL1_VsP_noFcut1 = dir.make<TH2D>("K_and_C_Ih_noL1_VsP_noFcut1",";Ih_noL1_VsP_noFcut1", 50,0,5, 80, 2.,10.);
-    tuple->K_and_C_Ih_noL1_VsP_noFcut2 = dir.make<TH2D>("K_and_C_Ih_noL1_VsP_noFcut2",";Ih_noL1_VsP_noFcut2", 250,0,50, 80, 2.,10.);
-    tuple->K_and_C_Ih_strip_VsP_noFcut1 = dir.make<TH2D>("K_and_C_Ih_strip_VsP_noFcut1",";Ih_strip_VsP_noFcut1", 50,0,5, 80, 2.,10.);
-    tuple->K_and_C_Ih_strip_VsP_noFcut2 = dir.make<TH2D>("K_and_C_Ih_strip_VsP_noFcut2",";Ih_strip_VsP_noFcut2", 250,0,50, 80, 2.,10.);
+    tuple->K_and_C_Ih_noL1_VsP_1 = dir.make<TH2D>("K_and_C_Ih_noL1_VsP_1",";Ih_noL1_VsP_1", 50,0,5, 240, 2., 14.);
+    tuple->K_and_C_Ih_noL1_VsP_2 = dir.make<TH2D>("K_and_C_Ih_noL1_VsP_2",";Ih_noL1_VsP_2", 250,0,50, 240, 2., 14.);
+    tuple->K_and_C_Ih_noL1_VsP_eta1_1 = dir.make<TH2D>("K_and_C_Ih_noL1_VsP_eta1_1",";Ih_noL1_VsP_eta1_1", 50,0,5, 240, 2., 14.);
+    tuple->K_and_C_Ih_noL1_VsP_eta1_2 = dir.make<TH2D>("K_and_C_Ih_noL1_VsP_eta1_2",";Ih_noL1_VsP_eta1_2", 250,0,50, 240, 2., 14.);
+    tuple->K_and_C_Ih_noL1_VsP_eta2_1 = dir.make<TH2D>("K_and_C_Ih_noL1_VsP_eta2_1",";Ih_noL1_VsP_eta2_1", 50,0,5, 240, 2., 14.);
+    tuple->K_and_C_Ih_noL1_VsP_eta2_2 = dir.make<TH2D>("K_and_C_Ih_noL1_VsP_eta2_2",";Ih_noL1_VsP_eta2_2", 250,0,50, 240, 2., 14.);
+    tuple->K_and_C_Ih_strip_VsP_1 = dir.make<TH2D>("K_and_C_Ih_strip_VsP_1",";Ih_strip_VsP_1", 50,0,5, 240, 2., 14.);
+    tuple->K_and_C_Ih_strip_VsP_2 = dir.make<TH2D>("K_and_C_Ih_strip_VsP_2",";Ih_strip_VsP_2", 250,0,50, 240, 2., 14.);
+    tuple->K_and_C_Ih_noL1_VsP_noFcut1 = dir.make<TH2D>("K_and_C_Ih_noL1_VsP_noFcut1",";Ih_noL1_VsP_noFcut1", 50,0,5, 240, 2., 14.);
+    tuple->K_and_C_Ih_noL1_VsP_noFcut2 = dir.make<TH2D>("K_and_C_Ih_noL1_VsP_noFcut2",";Ih_noL1_VsP_noFcut2", 250,0,50, 240, 2., 14.);
+    tuple->K_and_C_Ih_strip_VsP_noFcut1 = dir.make<TH2D>("K_and_C_Ih_strip_VsP_noFcut1",";Ih_strip_VsP_noFcut1", 50,0,5, 240, 2., 14.);
+    tuple->K_and_C_Ih_strip_VsP_noFcut2 = dir.make<TH2D>("K_and_C_Ih_strip_VsP_noFcut2",";Ih_strip_VsP_noFcut2", 250,0,50, 240, 2., 14.);
+
+    tuple->K_and_C_Ih_noL1_1d = dir.make<TH1F>("K_and_C_Ih_noL1_1d",";Ih_noL1 (for 3<p<5)",170,2.5,4.2);
+    tuple->K_and_C_Ih_strip_1d = dir.make<TH1F>("K_and_C_Ih_strip_1d",";Ih_noL1 (for 3<p<5)",170,2.5,4.2);
 
     tuple->K_and_C_Kin_Mass = dir.make<TH1F>("K_and_C_Kin_Mass",";Mass (GeV)",100,0.,5.);
     tuple->K_and_C_Kin_p = dir.make<TH1F>("K_and_C_Kin_p",";p (GeV)",50,0.,5.);

--- a/Analyzer/plugins/Analyzer.cc
+++ b/Analyzer/plugins/Analyzer.cc
@@ -3476,6 +3476,20 @@ void Analyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) 
       tuple->PostPreS_Pt_lowPt_CR->Fill(track->pt(), eventWeight_);
       tuple->PostPreS_ProbQNoL1_CR->Fill(1 - probQonTrackNoL1, eventWeight_);
       tuple->PostPreS_ProbQNoL1VsIas_CR->Fill(1 - probQonTrackNoL1, globalIas_, eventWeight_);
+
+      tuple->PostPreS_Ih_CR->Fill(globalIh_,eventWeight_);
+      tuple->PostPreS_Ihstrip_CR->Fill((dedxIh_StripOnly ? dedxIh_StripOnly->dEdx() : -1) ,eventWeight_);
+      tuple->PostPreS_Ih_nopixcl_CR->Fill((dedxtest_nopixcl ? dedxtest_nopixcl->dEdx() : -1) ,eventWeight_);
+
+
+      float Masstest =0;
+      if (globalIh_>3.18) Masstest= GetMass(track->p(), globalIh_, 2.52, 3.18);  // K and C values fixed to some test values
+      if ((1 - probQonTrackNoL1)<0.9) {
+         tuple->PostPreS_MassVsIas_fail_CR->Fill(globalIas_, Masstest, eventWeight_);
+      }
+      else {
+          tuple->PostPreS_MassVsIas_pass_CR->Fill(globalIas_, Masstest,  eventWeight_);
+      }
       if (doSystsPlots_) {
         tuple->PostPreS_ProbQNoL1VsIas_CR_Pileup_up->Fill(1 - probQonTrackNoL1, globalIas_,  eventWeight_ * PUSystFactor_[0]);
         tuple->PostPreS_ProbQNoL1VsIas_CR_Pileup_down->Fill(1 - probQonTrackNoL1, globalIas_,  eventWeight_ * PUSystFactor_[1]);
@@ -5732,6 +5746,10 @@ void Analyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) 
 
         tuple->K_and_C_Ih_noL1_VsP_1->Fill(generalTrack->p(),ih0_noL1, preScaleForDeDx*eventWeight_);
         tuple->K_and_C_Ih_noL1_VsP_2->Fill(generalTrack->p(),ih0_noL1, preScaleForDeDx*eventWeight_);
+        if (generalTrack->p()>3. && generalTrack->p()<5.) {
+             tuple->K_and_C_Ih_noL1_1d->Fill(ih0_noL1, preScaleForDeDx*eventWeight_);
+             tuple->K_and_C_Ih_strip_1d->Fill(ih0_strip, preScaleForDeDx*eventWeight_);
+        }
         if (fabs(generalTrack->eta())<1) {
              tuple->K_and_C_Ih_noL1_VsP_eta1_1->Fill(generalTrack->p(),ih0_noL1, preScaleForDeDx*eventWeight_);
              tuple->K_and_C_Ih_noL1_VsP_eta1_2->Fill(generalTrack->p(),ih0_noL1, preScaleForDeDx*eventWeight_);
@@ -5798,6 +5816,13 @@ void Analyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) 
                      tuple->SF_HHit2DStrip_nosf->Fill(generalTrack->p(), charge_over_path_nosf, preScaleForDeDx*eventWeight_);
                    }
                  }
+                 if ( fabs(dzForCalib) < globalMaxDZ_ && fabs(dxyForCalib) < globalMaxDXY_) {
+                     tuple->SF_HHit2DStrip_eta1->Fill(generalTrack->p(), charge_over_pathlength, preScaleForDeDx*eventWeight_);
+                     tuple->SF_HHit2DStrip_nosf_eta1->Fill(generalTrack->p(), charge_over_path_nosf, preScaleForDeDx*eventWeight_);
+                      if (generalTrack->pt()>10 && generalTrack->pt()<50) {
+                        tuple->SF_HHit2DStrip_vs_eta->Fill(generalTrack->eta(), charge_over_pathlength, preScaleForDeDx*eventWeight_);
+                      }
+                 }
               }
            }
            else {
@@ -5808,10 +5833,46 @@ void Analyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) 
               scaleFactor *= pixelScaling;
               float charge_over_pathlength = dedx_charge * scaleFactor * factorChargeToE / dedx_pathlength;
               float charge_over_path_nosf = dedx_charge * factorChargeToE / dedx_pathlength;
-              // BPIXL1
+
+//
+              // Taking the pixel cluster
+              auto const* pixelCluster =  dedxHits->pixelCluster(h);
+              if (pixelCluster == nullptr)  continue;
+              // Check on which geometry unit the hit is
+              const GeomDetUnit& geomDet = *tkGeometry->idToDetUnit(detid);
+              // Get the local vector for the track direction
+              LocalVector lv = geomDet.toLocal(GlobalVector(generalTrack->px(), generalTrack->py(), generalTrack->pz()));
+              // Re-run the CPE on this cluster with the lv above
+              // getParameters will return std::tuple<LocalPoint, LocalError, SiPixelRecHitQuality::QualWordType>;
+              // from this we pick the 2nd, the QualWordType
+              auto reCPE = std::get<2>(pixelCPE->getParameters(*pixelCluster, geomDet, LocalTrajectoryParameters(dedxHits->pos(h), lv, generalTrack->charge())));
+              // extract probQ and probXY from this
+              float probQ = SiPixelRecHitQuality::thePacking.probabilityQ(reCPE);
+
+              // To measure how often the CPE fails
+              bool cpeHasFailed = false;
+              if (!SiPixelRecHitQuality::thePacking.hasFilledProb(reCPE)) {
+                  cpeHasFailed = true;
+              }
+              if (cpeHasFailed) continue;
+
+              if (probQ <= 0.0 || probQ >= 1.f) probQ = 1.f;
+
+              bool isOnEdge = SiPixelRecHitQuality::thePacking.isOnEdge(reCPE);
+              bool hasBadPixels = SiPixelRecHitQuality::thePacking.hasBadPixels(reCPE);
+              bool spansTwoROCs = SiPixelRecHitQuality::thePacking.spansTwoROCs(reCPE);
+              bool specInCPE = (isOnEdge || hasBadPixels || spansTwoROCs) ? true : false;
+
+
+              // BPIXL1 only for 2017 and 2018
               bool isBPIXL1=false;
-              if (detid.subdetId() == 1 && ((detid >> 20) & 0xF) == 1) isBPIXL1=true;
-              if (!isBPIXL1) {
+//              if (detid.subdetId() == 1 && ((detid >> 20) & 0xF) == 1) isBPIXL1=true;
+              int numLayers = tkGeometry->numberOfLayers(PixelSubdetector::PixelBarrel);
+              if ((numLayers == 4) && ((detid.subdetId() == PixelSubdetector::PixelBarrel) && (tTopo->pxbLayer(detid) == 1))) isBPIXL1=true;
+
+               // cleaning in the pixel 
+              if (!specInCPE && probQ < 0.8 && (!isBPIXL1)) {
+//              if ((!isBPIXL1)) {
                  if (fabs(generalTrack->eta()<0.4)){
                    tuple->SF_HHit2DPix_loose->Fill(generalTrack->p(), charge_over_pathlength, preScaleForDeDx*eventWeight_);
                    if ( fabs(dzForCalib) < globalMaxDZ_ && fabs(dxyForCalib) < globalMaxDXY_) {
@@ -5819,6 +5880,15 @@ void Analyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) 
                       tuple->SF_HHit2DPix_nosf->Fill(generalTrack->p(), charge_over_path_nosf, preScaleForDeDx*eventWeight_);
                    }
                  }
+                 if ( fabs(dzForCalib) < globalMaxDZ_ && fabs(dxyForCalib) < globalMaxDXY_) {
+                      tuple->SF_HHit2DPix_eta1->Fill(generalTrack->p(), charge_over_pathlength, preScaleForDeDx*eventWeight_);
+                      tuple->SF_HHit2DPix_nosf_eta1->Fill(generalTrack->p(), charge_over_path_nosf, preScaleForDeDx*eventWeight_);
+                      if (generalTrack->pt()>10 && generalTrack->pt()<50) {
+                        tuple->SF_HHit2DPix_vs_eta->Fill(generalTrack->eta(), charge_over_pathlength, preScaleForDeDx*eventWeight_);
+                      }
+
+                 }
+
               }
            }
 


### PR DESCRIPTION
PR with some problem observed. 
When swtiching between different selections for pixel, it impacts the number of entries in a Strip plot. Super wierd...

(For Tamas: I have changed at some places the layer decoding using tTopo. It remains only some access to direct decoding of the detid in the function [GetSFPixel](https://github.com/carolinecollard/SUSYBSMAnalysis-HSCP/blob/master/Analyzer/interface/CommonFunction.h#L254), because I didn't want to modify the arguments of the function due to the need of tTopo, and therefore change all the call to this function... for the future...)