### PR TITLE
Correction of a bug in GetSFPixel (a parenthesis misplaced)

### DIFF
--- a/Analyzer/interface/CommonFunction.h
+++ b/Analyzer/interface/CommonFunction.h
@@ -323,7 +323,6 @@ float GetSFPixel(int subdetid_, UInt_t detid_, string year, int run) {
 
      }
      else if (layerorside==3) {
-     }
 
        if (year=="2017") {
         for (int i=0; i<icalibL3_2017; i++) {
@@ -346,6 +345,7 @@ float GetSFPixel(int subdetid_, UInt_t detid_, string year, int run) {
         }
        }
 
+     }
      else if (layerorside==4) {
 
        if (year=="2017") {

--- a/Analyzer/plugins/Analyzer.cc
+++ b/Analyzer/plugins/Analyzer.cc
@@ -3466,7 +3466,9 @@ void Analyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) 
 
       float Masstest =0;
       // K and C values fixed to some test values
-      if (dedxIh_StripOnly->dEdx() > 3.18) Masstest= GetMass(track->p(), globalIh_, 2.52, 3.18);
+      if (dedxIh_StripOnly) {
+         if (dedxIh_StripOnly->dEdx() > 3.18) Masstest= GetMass(track->p(), dedxIh_StripOnly->dEdx(), 2.52, 3.18);
+      }
       if ((1 - probQonTrackNoL1)<0.9) {
          tuple->PostPreS_MassVsIas_fail_CR->Fill(globalIas_, Masstest, eventWeight_);
       }


### PR DESCRIPTION
Correction of a bug found in the GetSFPixel() function : One parenthesis was misplaced. 
The consequence of this is that the SF for all layers in Barrel Pix were always overwritten by the SF for Layer3 Barrel Pixel. This should have no consequence for the Ionization-based  analysis (using F and G) as you don't explicitely use the charge in the pixel but the templates. Only the Mass Reco Analysis is affected, as GetSFPixel --> dEdX SF --> Ih noL1 --> K and C --> Mass. 