### PR TITLE
remove the individual probQ cut for DeDx SF and Ih

### DIFF
--- a/Analyzer/interface/CommonFunction.h
+++ b/Analyzer/interface/CommonFunction.h
@@ -1609,7 +1609,8 @@ reco::DeDxData computedEdx(const float& track_eta,
         bool specInCPE = (isOnEdge || hasBadPixels || spansTwoROCs) ? true : false;
 
         if (specInCPE) continue;
-        if (probQ>0.8) continue;
+//        20 March 2023 : no cut on individual probQ for Ih computation
+//        if (probQ>0.8) continue;
 
     }
     if (detid.subdetId() >= 3) {  //for strip only

--- a/Analyzer/interface/Tuple.h
+++ b/Analyzer/interface/Tuple.h
@@ -759,6 +759,8 @@ struct Tuple {
   TH2F* PostPreS_ProbXYVsIas_highIas;
   TH2F* PostPreS_ProbXYVsProbQ;
   TH2F* PostPreS_ProbXYVsProbQ_highIas;
+  TH2F* PostPreS_MassVsIas_fail;
+  TH2F* PostPreS_MassVsIas_pass;
 
   TH1F* PostPreS_Ias_CR;
   TH1F* PostPreS_Ih_CR;

--- a/Analyzer/interface/TupleMaker.h
+++ b/Analyzer/interface/TupleMaker.h
@@ -1145,8 +1145,8 @@ void TupleMaker::initializeTuple(Tuple *&tuple,
     tuple->PostPreS_Ihstrip_CR= dir.make<TH1F>("PostPreS_Ihstrip_CR", ";I_{h} (strip only) (MeV/cm)", 200, 0, dEdxM_UpLim);
     tuple->PostPreS_Ih_nopixcl_CR= dir.make<TH1F>("PostPreS_Ih_nopixcl_CR", ";I_{h}(no pix cleaning) (MeV/cm)", 200, 0, dEdxM_UpLim);
     tuple->PostPreS_Pt_lowPt_CR = dir.make<TH1F>("PostPreS_Pt_lowPt_CR", ";p_{T} (GeV);Tracks / 10 GeV", 50, 0., 500.);
-    tuple->PostPreS_MassVsIas_fail_CR= dir.make<TH2F>("PostPreS_MassVsIas_fail_CR", ";G_{i}^{strips} in Fail ;Mass(GeV)", 10,0., 1., 80, 0., 400.);
-    tuple->PostPreS_MassVsIas_pass_CR= dir.make<TH2F>("PostPreS_MassVsIas_pass_CR", ";G_{i}^{strips} in Pass ;Mass(GeV)", 10,0., 1., 80, 0., 400.);
+    tuple->PostPreS_MassVsIas_fail_CR= dir.make<TH2F>("PostPreS_MassVsIas_fail_CR", ";G_{i}^{strips} in Fail ;Mass(GeV)", 20,0., 1., 80, 0., 400.);
+    tuple->PostPreS_MassVsIas_pass_CR= dir.make<TH2F>("PostPreS_MassVsIas_pass_CR", ";G_{i}^{strips} in Pass ;Mass(GeV)", 20,0., 1., 80, 0., 400.);
 
 
     tuple->PostPreS_Ias_CR_veryLowPt = dir.make<TH1F>("PostPreS_Ias_CR_veryLowPt", ";G_{i}^{strips};Tracks / 0.1", 10, 0, dEdxS_UpLim);
@@ -1223,6 +1223,9 @@ void TupleMaker::initializeTuple(Tuple *&tuple,
     tuple->PostPreS_ProbXYVsIas_highIas = dir.make<TH2F>("PostPreS_ProbXYVsIas_highIas", ";ProbXY (G_{i}^{strips} > 0.6);G_{i}^{strips} (G_{i}^{strips} > 0.6);Tracks / bin",  100, 0, 1, 10, 0., 1.);
     tuple->PostPreS_ProbXYVsProbQ = dir.make<TH2F>("PostPreS_ProbXYVsProbQ", ";Prob_{XY,pixelAV} (pixels);F_{i}^{pixels};Tracks / bin",  100, 0., 1., 10, 0., 1.);
     tuple->PostPreS_ProbXYVsProbQ_highIas = dir.make<TH2F>("PostPreS_ProbXYVsProbQ_highIas", ";ProbXY (G_{i}^{strips} > 0.6);ProbQ (G_{i}^{strips} > 0.6);Tracks / bin",  100, 0., 1., 10, 0., 1.);
+
+    tuple->PostPreS_MassVsIas_fail= dir.make<TH2F>("PostPreS_MassVsIas_fail", "TO BLIND ! ;G_{i}^{strips} in Fail ;Mass(GeV)", 20,0., 1., 80, 0., 4000.);
+    tuple->PostPreS_MassVsIas_pass= dir.make<TH2F>("PostPreS_MassVsIas_pass", "TO BLIND ! ;G_{i}^{strips} in Pass ;Mass(GeV)", 20,0., 1., 80, 0., 4000.);
     
     tuple->PostPreS_ProbQNoL1_CR = dir.make<TH1F>("PostPreS_ProbQNoL1_CR", ";F_{i}^{pixels};Tracks / 0.05", 20, 0., 1.);
     

--- a/Analyzer/plugins/Analyzer.cc
+++ b/Analyzer/plugins/Analyzer.cc
@@ -646,6 +646,8 @@ void Analyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) 
   bool HLT_PFHT500_PFMET100_PFMHT100_IDTight = false;
   bool HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_PFHT60 = false;
   bool HLT_MET105_IsoTrk50 = false;
+  bool HLT_isoMu24 = false;
+  bool HLT_isoMu27 = false;
   
   bool metTrig = passTriggerPatterns(triggerH, triggerNames, trigger_met_);
   bool muTrig = passTriggerPatterns(triggerH, triggerNames, trigger_mu_);
@@ -662,6 +664,10 @@ void Analyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) 
       HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_PFHT60 = true;
     if (TString(triggerNames.triggerName(i)).Contains("HLT_MET105_IsoTrk50_v") && triggerH->accept(i))
       HLT_MET105_IsoTrk50 = true;
+    if (TString(triggerNames.triggerName(i)).Contains("HLT_isoMu27_v") && triggerH->accept(i))
+      HLT_isoMu27 = true;
+    if (TString(triggerNames.triggerName(i)).Contains("HLT_isoMu24_v") && triggerH->accept(i))
+      HLT_isoMu24 = true;
   }
 
   // Should this be a bin in error histo?
@@ -3468,7 +3474,7 @@ void Analyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) 
 
       float Masstest =0;
       // K and C values fixed to some test values
-      if (dedxIh_StripOnly->dEdx() > 3.18) Masstest= GetMass(track->p(), globalIh_, 2.52, 3.18);
+      if (dedxIh_StripOnly->dEdx() > 3.18) Masstest= GetMass(track->p(), dedxIh_StripOnly->dEdx(), 2.52, 3.18);
       if ((1 - probQonTrackNoL1)<0.9) {
          tuple->PostPreS_MassVsIas_fail_CR->Fill(globalIas_, Masstest, eventWeight_);
       }
@@ -3542,6 +3548,42 @@ void Analyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) 
               // Pixel corrections
               float pixelScaling = GetSFPixel(detid.subdetId(), detid, year, run_number);
               chargeForIndxH *= pixelScaling;
+
+
+              // Taking the pixel cluster
+              auto const* pixelCluster =  dedxHits->pixelCluster(h);
+              if (pixelCluster == nullptr)  continue;
+              // Check on which geometry unit the hit is
+              const GeomDetUnit& geomDet = *tkGeometry->idToDetUnit(detid);
+              // Get the local vector for the track direction
+              LocalVector lv = geomDet.toLocal(GlobalVector(track->px(), track->py(), track->pz()));
+              // Re-run the CPE on this cluster with the lv above
+              // getParameters will return std::tuple<LocalPoint, LocalError, SiPixelRecHitQuality::QualWordType>;
+              // from this we pick the 2nd, the QualWordType
+              auto reCPE = std::get<2>(pixelCPE->getParameters(*pixelCluster, geomDet, LocalTrajectoryParameters(dedxHits->pos(h), lv, track->charge())));
+              // extract probQ and probXY from this
+              //float probQ = SiPixelRecHitQuality::thePacking.probabilityQ(reCPE);
+              // To measure how often the CPE fails
+              bool cpeHasFailed = false;
+              if (!SiPixelRecHitQuality::thePacking.hasFilledProb(reCPE)) {
+                  cpeHasFailed = true;
+              }
+              if (cpeHasFailed) continue;
+
+             //  if (probQ <= 0.0 || probQ >= 1.f) probQ = 1.f;
+
+              bool isOnEdge = SiPixelRecHitQuality::thePacking.isOnEdge(reCPE);
+              bool hasBadPixels = SiPixelRecHitQuality::thePacking.hasBadPixels(reCPE);
+              bool spansTwoROCs = SiPixelRecHitQuality::thePacking.spansTwoROCs(reCPE);
+              bool specInCPE = (isOnEdge || hasBadPixels || spansTwoROCs) ? true : false;
+
+             //  bool isBPIXL1=false;
+             //  int numLayers = tkGeometry->numberOfLayers(PixelSubdetector::PixelBarrel);
+             //  if ((numLayers == 4) && ((detid.subdetId() == PixelSubdetector::PixelBarrel) && (tTopo->pxbLayer(detid) == 1))) isBPIXL1=true;
+
+             // cleaning in the pixel : ok if (!specInCPE) 
+              if (specInCPE) cleaning = false;
+
         }
         else {
               // saturation correction of the charge
@@ -4007,6 +4049,21 @@ void Analyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) 
         tuple->PostPreS_ProbQNoL1->Fill(1 - probQonTrackNoL1, eventWeight_);
         tuple->PostPreS_ProbQNoL1VsIas->Fill(1 - probQonTrackNoL1, globalIas_, eventWeight_);
         tuple->PostPreS_ProbQNoL1VsFiStrips->Fill(1 - probQonTrackNoL1, globalFiStrips_, eventWeight_);
+
+
+        // test --> Need to blind the data at the drawing
+        // for the moment K and C are hard-coded...
+        float Masstest =0;
+        // K and C values fixed to some test values
+        if (dedxIh_StripOnly->dEdx() > 3.18) Masstest= GetMass(track->p(), dedxIh_StripOnly->dEdx(), 2.52, 3.18);
+        if ((1 - probQonTrackNoL1)<0.9) {
+           tuple->PostPreS_MassVsIas_fail->Fill(globalIas_, Masstest, eventWeight_);
+        }
+        else {
+            tuple->PostPreS_MassVsIas_pass->Fill(globalIas_, Masstest,  eventWeight_);
+        }
+
+
         if (doSystsPlots_) {
           tuple->PostPreS_ProbQNoL1VsIas_Pileup_up->Fill(1 - probQonTrackNoL1, globalIas_,  eventWeight_ * PUSystFactor_[0]);
           tuple->PostPreS_ProbQNoL1VsIas_Pileup_down->Fill(1 - probQonTrackNoL1, globalIas_,  eventWeight_ * PUSystFactor_[1]);
@@ -5564,7 +5621,8 @@ void Analyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) 
       std::fill(std::begin(passedTrackCutsArray), std::end(passedTrackCutsArray),true);
 
       // Pass the trigger
-      passedTrackCutsArray[0]  = (trigInfo_ > 0) ? true : false;
+//      passedTrackCutsArray[0]  = (trigInfo_ > 0) ? true : false;
+      passedTrackCutsArray[0]  = ((trigInfo_ > 0) || HLT_isoMu27 || HLT_isoMu24) ? true : false;
       // Check if eta is inside the max eta cut for detector homogeneity
       passedTrackCutsArray[1]  = (fabs(generalTrack->eta()) < globalMaxEta_) ? true : false;
       // Select only high purity tracks to ensure good quality tracks
@@ -5880,7 +5938,9 @@ void Analyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) 
             if ((numLayers == 4) && ((detid.subdetId() == PixelSubdetector::PixelBarrel) && (tTopo->pxbLayer(detid) == 1))) isBPIXL1=true;
 
              // cleaning in the pixel
-            if ((!specInCPE) && (probQ < 0.8) && (!isBPIXL1)) {
+//            if ((!specInCPE) && (probQ < 0.8) && (!isBPIXL1)) {
+//            No cut on individual probQ
+            if ((!specInCPE)  && (!isBPIXL1)) {
               if (fabs(generalTrack->eta()<0.4)) {
                 tuple->SF_HHit2DPix_loose->Fill(generalTrack->p(), charge_over_pathlength, preScaleForDeDx*eventWeight_);
                 if ( fabs(dzForCalib) < globalMaxDZ_ && fabs(dxyForCalib) < globalMaxDXY_) {


### PR DESCRIPTION
1) Add HLT_isoMu27 or 24 for SF_HH* and K_and_C* in order to increase the statistics...

2) Remove the individual probQ cut in the pixel cleaning for the SF_HH* and also Ih computation (as suggested by Morris -- if I understood correctly the proposal). 

3) Add the cleaning of the pixel for PostPreS_CpPL_pix_CR_veryLowPt, no individual probQ cut. 
question on line [3571 of Analyzer.cc](https://github.com/carolinecollard/SUSYBSMAnalysis-HSCP/blob/master/Analyzer/plugins/Analyzer.cc#L3571), should I set the cleaning boolean to false in that case to not consider the cluster with cpeHasFailed  ? The [modification](https://github.com/carolinecollard/SUSYBSMAnalysis-HSCP/blob/master/Analyzer/plugins/Analyzer.cc#L3553:L3585) will modifiy the entry in the Gi templates for pixel, but we don't use the Gi pixel templates, so no need to produce a new template version right now...

4) Add plots of Mass vs Ias in pass/fail region after preselection, the blinding would need to be applied before drawing. use Ih(strip only) for the Mass computation. K and C hard-coded for the moment... 

